### PR TITLE
update ooo dependency to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benitogf/coat v0.0.0-20200402073050-ff807656cbec
 	github.com/benitogf/go-json v0.0.0-20260410172501-727f5690408b
 	github.com/benitogf/ko v0.0.0-20260211072652-d48fcf4f8988
-	github.com/benitogf/ooo v0.0.0-20260417050250-1a30088df9d8
+	github.com/benitogf/ooo v0.0.0-20260422045849-868300e72a73
 	github.com/gorilla/mux v1.8.1
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/benitogf/jsonpatch v0.0.0-20260413094158-a4a6cc1a3382 h1:invi4tSUoH4H
 github.com/benitogf/jsonpatch v0.0.0-20260413094158-a4a6cc1a3382/go.mod h1:ZOQm93UFJwYDZLHQVGt2/JmNOltb6LRIJUuys0uMWKY=
 github.com/benitogf/ko v0.0.0-20260211072652-d48fcf4f8988 h1:sagWGc0GUBEMxa56HpjlYh6MmUt2O4vZrqlTspHotYc=
 github.com/benitogf/ko v0.0.0-20260211072652-d48fcf4f8988/go.mod h1:fRbtp9nrkNeDXowzM7KRJP6TL6OMsAyroUylQCw+77s=
-github.com/benitogf/ooo v0.0.0-20260417050250-1a30088df9d8 h1:l4YgQNE5lu6rLfQUD5GQTdH31pSHFaYvldcWzB6I60s=
-github.com/benitogf/ooo v0.0.0-20260417050250-1a30088df9d8/go.mod h1:WvPwWgfK2mo3UKfR+BM/9hwHe+ZjVwZZ3rxOPcBcXnw=
+github.com/benitogf/ooo v0.0.0-20260422045849-868300e72a73 h1:Aqo+xOCfOKpjxBSLhPZ6fiaEOltQFMi4h5Xt2gOhI0s=
+github.com/benitogf/ooo v0.0.0-20260422045849-868300e72a73/go.mod h1:WvPwWgfK2mo3UKfR+BM/9hwHe+ZjVwZZ3rxOPcBcXnw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=


### PR DESCRIPTION
## Summary
Pulls in the upstream memory-first change for list reads. GetList no longer opens a disk iterator on every call when the in-memory layer holds the data.

## Reference
- Upstream: benitogf/ooo#40

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)