### PR TITLE
Audit cleanup: registry leak, panic-safe callbacks, dead code

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -240,3 +240,12 @@ func storeInstance(server *ooo.Server, instance *Instance) {
 	instances[server] = instance
 	instancesMu.Unlock()
 }
+
+// removeInstance drops the entry from the registry. Called on shutdown so a
+// process that recreates servers (tests, supervised in-process restarts)
+// doesn't leak one map entry per server for the rest of the process's life.
+func removeInstance(server *ooo.Server) {
+	instancesMu.Lock()
+	delete(instances, server)
+	instancesMu.Unlock()
+}

--- a/instance_lifecycle_test.go
+++ b/instance_lifecycle_test.go
@@ -1,0 +1,47 @@
+package pivot
+
+// Regression test for the instances-map leak: every Setup adds an entry to
+// the package-level registry; Shutdown / server.Close() must remove it so
+// that a process recreating servers (tests, supervised restarts) doesn't
+// retain dead Instance pointers for the rest of its life.
+
+import (
+	"testing"
+
+	"github.com/benitogf/ooo"
+	"github.com/benitogf/ooo/monotonic"
+	"github.com/benitogf/ooo/storage"
+	"github.com/gorilla/mux"
+)
+
+func TestInstanceRegistryRemovedOnShutdown(t *testing.T) {
+	monotonic.Init()
+	server := &ooo.Server{
+		Router:  mux.NewRouter(),
+		Silence: true,
+		Storage: storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()}),
+	}
+	Setup(server, Config{
+		Keys:       []Key{{Path: "items/*"}},
+		ClusterURL: "",
+	})
+	server.Start("localhost:0")
+
+	// After Setup the registry must contain this server.
+	instancesMu.RLock()
+	_, present := instances[server]
+	instancesMu.RUnlock()
+	if !present {
+		t.Fatalf("expected instances[server] to be set after Setup")
+	}
+
+	// Close drives RegisterPreClose, which must drop the registry entry.
+	server.Close(nil)
+
+	instancesMu.RLock()
+	_, stillPresent := instances[server]
+	instancesMu.RUnlock()
+	if stillPresent {
+		t.Fatalf("instances[server] still set after Close — registry leaks one entry per server lifecycle")
+	}
+}

--- a/nodehealth.go
+++ b/nodehealth.go
@@ -358,10 +358,13 @@ func (nh *NodeHealth) MarkHealthy(node string) {
 	}
 	nh.mu.Unlock()
 
-	// Notify if status changed
+	// Notify if status changed. Wrap in a closure with deferred Done so a
+	// panicking user callback can't leak the wait-group counter and hang Stop().
 	if !wasHealthy && callback != nil {
-		callback()
-		nh.callbackWg.Done()
+		func() {
+			defer nh.callbackWg.Done()
+			callback()
+		}()
 	}
 }
 
@@ -381,9 +384,12 @@ func (nh *NodeHealth) MarkUnhealthy(node string) {
 	}
 	nh.mu.Unlock()
 
-	// Notify if status changed
+	// Notify if status changed. Wrap in a closure with deferred Done so a
+	// panicking user callback can't leak the wait-group counter and hang Stop().
 	if wasHealthy && callback != nil {
-		callback()
-		nh.callbackWg.Done()
+		func() {
+			defer nh.callbackWg.Done()
+			callback()
+		}()
 	}
 }

--- a/pivot.go
+++ b/pivot.go
@@ -95,11 +95,11 @@ func parseNodeAddr(data []byte) string {
 	}
 	var port int
 	for _, k := range [2]string{"port", "Port"} {
+		// encoding/json decodes JSON numbers into float64 for map[string]any.
+		// String fallback covers values written as quoted numbers.
 		switch v := raw[k].(type) {
 		case float64:
 			port = int(v)
-		case int:
-			port = v
 		case string:
 			port, _ = strconv.Atoi(v)
 		}
@@ -554,12 +554,14 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 	}
 	instance.VVManager = vvManager
 
-	// Shutdown instance and VVManager before storage closes to prevent race conditions
+	// Shutdown instance and VVManager before storage closes to prevent race conditions.
+	// removeInstance drops the registry entry so re-creating the server doesn't leak.
 	server.RegisterPreClose(func() {
 		instance.Shutdown()
 		if vvManager != nil {
 			vvManager.Shutdown()
 		}
+		removeInstance(server)
 	})
 
 	syncCallback := makeStorageSync(StorageSyncConfig{

--- a/sync.go
+++ b/sync.go
@@ -300,38 +300,6 @@ func synchronizeKeysWithTracking(clientOpts ClientOpts, opts SyncOptions, keys [
 	return errors.New("nothing to synchronize")
 }
 
-// pullFromLeaderWithTracking syncs FROM leader and tracks synced keys.
-// Uses timestamp-based comparison.
-// onDelete is called for each key deleted locally, onSet is called for each key set locally.
-// skipSet is called before setting a key - if it returns true, the set is skipped.
-func pullFromLeaderWithTracking(clientOpts ClientOpts, opts SyncOptions, keys []Key) error {
-	update := false
-	for _, k := range keys {
-		baseKey := baseKeyFromPath(k.Path)
-		activityLeader, err := checkLeaderActivity(clientOpts, baseKey)
-		if err != nil {
-			continue
-		}
-		activityLocal, err := checkActivity(k)
-		if err != nil {
-			continue
-		}
-		// Only sync if leader has newer data
-		if activityLeader.LastEntry > activityLocal.LastEntry {
-			keyOpts := opts
-			keyOpts.Key = k
-			keyOpts.LastEntry = activityLeader.LastEntry
-			if err := syncLocalEntriesWithTracking(clientOpts, keyOpts); err == nil {
-				update = true
-			}
-		}
-	}
-	if update {
-		return nil
-	}
-	return errors.New("nothing to synchronize")
-}
-
 // pullTracker tracks keys that are being modified during sync operations.
 // Keys are tracked before storage operations and consumed (removed) when checked.
 // This ensures each storage event is only skipped once.


### PR DESCRIPTION
## Summary
Closes #26.

Four small audit findings bundled into one focused PR. Each is contained, none touch the public API, on-disk format is unchanged.

**Registry leak.** The package-level `instances` map was append-only — `Shutdown()` didn't `delete()` the entry. Long-running processes that recreate servers (test runs, supervised in-process restarts) leaked one map entry per server lifecycle for the rest of the process. Fixed by adding a `removeInstance()` helper called from the existing `RegisterPreClose` hook alongside `instance.Shutdown()` and `vvManager.Shutdown()`. Pinned by a regression test.

**Callback panic safety.** `MarkHealthy` and `MarkUnhealthy` did `callbackWg.Add(1)` before the user callback fired, then `Done()` after — without `defer`. A panicking callback would leak the counter and hang `Stop()` forever. Fixed by wrapping the callback invocation in a closure with deferred `Done()`.

**Dead code.** `pullFromLeaderWithTracking` had no callers anywhere — drift surface since the last sync refactor. Removed.

**Unreachable branch.** `parseNodeAddr`'s port type switch had a `case int` that can never match — `encoding/json` always decodes JSON numbers into `float64` for `map[string]any` targets. Removed and added a one-line comment so the next reader doesn't re-add it.

## Audit claim verified-and-rejected

The audit also flagged `healthClient` as being allocated per-tick. Inspection showed the client is already declared *outside* the per-tick closure (`pivot.go:778`, before `checkHealth` opens at `:780`); every tick reuses the same `*http.Client`. The audit finding didn't reflect the actual code structure. No change needed; the rejection is documented in our internal review notes for future reviewers.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` 7.3s green
- [x] `go test -race ./...` 9.1s green
- [x] New regression test (`TestInstanceRegistryRemovedOnShutdown`) pins the registry-leak fix: creates a server, asserts the entry is in the registry, drives `server.Close(nil)`, asserts the entry is gone.

## Diff stat
```
 instance.go                       |  9 +++++++++
 nodehealth.go                     | 18 ++++++++++++------
 pivot.go                          |  8 +++++---
 sync.go                           | 32 --------------------------------
 instance_lifecycle_test.go (new)  | 47 ++++++++++++++++++++++++++++++++
 5 files changed, 73 insertions(+), 41 deletions(-)
```

Net code reduction in production files (–41 deletions vs +26 insertions; the test adds 47 more).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)