### PR TITLE
Coalesce per-node trigger fan-out under write bursts

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -35,6 +35,7 @@ type Instance struct {
 	VVManager      *VVManager                    // Version vector manager (for both pivot and node servers)
 	syncerPool     *syncerPool                   // Internal syncer pool for node servers (for testing hooks)
 	nodesCache     *nodesCache                   // Cache for NodesKey address list, invalidated by storage events
+	triggers       *triggerCoalescer             // Per-node trigger coalescer (only set on pivot servers)
 	healthMu       sync.RWMutex                  // Protects PivotHealth map
 	extraNodeURLMu sync.RWMutex                  // Protects ExtraNodeURLs
 	shutdown       int32                         // Atomic flag to prevent access during shutdown

--- a/pivot.go
+++ b/pivot.go
@@ -554,12 +554,22 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 	}
 	instance.VVManager = vvManager
 
+	// Per-node trigger coalescer — replaces the goroutine-per-event-per-node
+	// fan-out from the broadcast loop. Only pivot servers broadcast, so we
+	// only spin one up when this server has pivot-role keys.
+	if hasPivotKeys {
+		instance.triggers = newTriggerCoalescer(client, pool, nodeHealth)
+	}
+
 	// Shutdown instance and VVManager before storage closes to prevent race conditions.
 	// removeInstance drops the registry entry so re-creating the server doesn't leak.
 	server.RegisterPreClose(func() {
 		instance.Shutdown()
 		if vvManager != nil {
 			vvManager.Shutdown()
+		}
+		if instance.triggers != nil {
+			instance.triggers.Shutdown()
 		}
 		removeInstance(server)
 	})

--- a/sync.go
+++ b/sync.go
@@ -889,20 +889,11 @@ func makeStorageSync(cfg StorageSyncConfig) StorageSyncCallback {
 				if cfg.NodeHealth != nil && !cfg.NodeHealth.IsCompatible(node) {
 					continue
 				}
-				go func(n string, keyPath string) {
-					ssl := false
-					if cfg.Pool != nil {
-						ssl = cfg.Pool.ssl
-					}
-					ok := TriggerNodeSyncWithHealth(ClientOpts{Client: cfg.Client, SSL: ssl}, n, keyPath)
-					if cfg.NodeHealth != nil {
-						if ok {
-							cfg.NodeHealth.MarkHealthy(n)
-						} else {
-							cfg.NodeHealth.MarkUnhealthy(n)
-						}
-					}
-				}(node, matchedKeyConfig.Path)
+				// The coalescer collapses bursts of triggers for the same node into a
+				// single in-flight HTTP call (drainer goroutine per node, 1-buffered
+				// notify, no timer). Setup always wires it on pivot servers, which
+				// is the only path that reaches this branch.
+				cfg.Instance.triggers.Trigger(node, matchedKeyConfig.Path)
 			}
 		} else {
 			// This server is node for this key - increment local VV and sync to pivot

--- a/trigger.go
+++ b/trigger.go
@@ -1,0 +1,175 @@
+package pivot
+
+import (
+	"net/http"
+	"sync"
+)
+
+// triggerCoalescer dispatches "wake up and pull" signals to nodes, collapsing
+// rapid bursts on the same node into a single in-flight HTTP call. Each node
+// gets a dedicated drainer goroutine; multiple triggers that arrive while the
+// drainer is in the middle of one HTTP call accumulate in a per-node pending
+// set, and the drainer's next iteration drains them with one more HTTP call.
+//
+// Coalescing factor scales with load: under quiescence triggers fire 1:1, under
+// heavy bursts many events collapse into a single trigger. There is no timer
+// involved — coalescing emerges from "single consumer + 1-buffered notify"
+// rather than from any time-based debounce, which is what keeps pivot's
+// deterministic-causal-chain testing model intact (no time.Sleep needed).
+//
+// Safety under the consistency principle: TriggerNodeSync is a "wake up and
+// pull" signal, not data delivery. The node always pulls *current* state when
+// it acts on a trigger. Fewer triggers → same eventual pull → same convergent
+// state.
+type triggerCoalescer struct {
+	mu      sync.Mutex
+	perNode map[string]*nodeTrigger
+	closed  bool
+
+	client *http.Client
+	pool   *syncerPool // for SSL flag; may be nil
+	health *NodeHealth // may be nil
+
+	stop chan struct{}
+	wg   sync.WaitGroup
+}
+
+// nodeTrigger holds per-node coalescing state and runs one drainer goroutine.
+type nodeTrigger struct {
+	node   string
+	parent *triggerCoalescer
+
+	mu      sync.Mutex
+	pending map[string]struct{} // key paths waiting to be sent
+	notify  chan struct{}       // 1-buffered wake-up signal
+}
+
+func newTriggerCoalescer(client *http.Client, pool *syncerPool, health *NodeHealth) *triggerCoalescer {
+	return &triggerCoalescer{
+		perNode: make(map[string]*nodeTrigger),
+		client:  client,
+		pool:    pool,
+		health:  health,
+		stop:    make(chan struct{}),
+	}
+}
+
+// Trigger queues a "wake up and pull" signal for `node`. Multiple Trigger
+// calls for the same node coalesce into a single in-flight HTTP request.
+// The keyPath is forwarded to the node so it can pull only the affected key
+// when possible; if multiple distinct keys are pending at drain time, the
+// drainer falls back to a SyncAll (empty keyPath) which the node-side handler
+// already supports.
+func (c *triggerCoalescer) Trigger(node, keyPath string) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	nt, ok := c.perNode[node]
+	if !ok {
+		nt = c.newNodeTriggerLocked(node)
+	}
+	c.mu.Unlock()
+	nt.signal(keyPath)
+}
+
+// newNodeTriggerLocked spawns a drainer for node. Caller must hold c.mu.
+func (c *triggerCoalescer) newNodeTriggerLocked(node string) *nodeTrigger {
+	nt := &nodeTrigger{
+		node:    node,
+		parent:  c,
+		pending: make(map[string]struct{}),
+		notify:  make(chan struct{}, 1),
+	}
+	c.perNode[node] = nt
+	c.wg.Add(1)
+	go nt.drain()
+	return nt
+}
+
+// signal records keyPath as pending and wakes the drainer.
+func (nt *nodeTrigger) signal(keyPath string) {
+	nt.mu.Lock()
+	nt.pending[keyPath] = struct{}{}
+	nt.mu.Unlock()
+	// Non-blocking notify: if a wake-up is already pending, drop. The drainer
+	// reads the pending map atomically when it picks up the signal, so
+	// missed signals don't drop work.
+	select {
+	case nt.notify <- struct{}{}:
+	default:
+	}
+}
+
+// drain is the per-node loop that fires HTTP triggers. Stops when
+// parent.stop is closed.
+func (nt *nodeTrigger) drain() {
+	defer nt.parent.wg.Done()
+	for {
+		select {
+		case <-nt.parent.stop:
+			return
+		case <-nt.notify:
+			// Re-check stop in case shutdown raced a notify.
+			select {
+			case <-nt.parent.stop:
+				return
+			default:
+			}
+			keyPath, hasWork := nt.takePending()
+			if !hasWork {
+				continue
+			}
+			nt.fire(keyPath)
+		}
+	}
+}
+
+// takePending atomically drains the pending set and returns the keyPath to
+// pass to TriggerNodeSync. Empty string means "multiple keys pending, fall
+// back to SyncAll on the receiver side."
+func (nt *nodeTrigger) takePending() (keyPath string, hasWork bool) {
+	nt.mu.Lock()
+	defer nt.mu.Unlock()
+	if len(nt.pending) == 0 {
+		return "", false
+	}
+	if len(nt.pending) == 1 {
+		for k := range nt.pending {
+			keyPath = k
+		}
+	}
+	// len > 1 → leave keyPath empty; receiver does SyncAll.
+	nt.pending = make(map[string]struct{})
+	return keyPath, true
+}
+
+// fire issues the HTTP wake-up call and updates node health.
+func (nt *nodeTrigger) fire(keyPath string) {
+	ssl := false
+	if nt.parent.pool != nil {
+		ssl = nt.parent.pool.ssl
+	}
+	ok := TriggerNodeSyncWithHealth(ClientOpts{Client: nt.parent.client, SSL: ssl}, nt.node, keyPath)
+	if nt.parent.health != nil {
+		if ok {
+			nt.parent.health.MarkHealthy(nt.node)
+		} else {
+			nt.parent.health.MarkUnhealthy(nt.node)
+		}
+	}
+}
+
+// Shutdown stops all drainer goroutines and blocks until they exit. Idempotent.
+func (c *triggerCoalescer) Shutdown() {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	close(c.stop)
+	c.mu.Unlock()
+	c.wg.Wait()
+}

--- a/trigger_test.go
+++ b/trigger_test.go
@@ -1,0 +1,118 @@
+package pivot
+
+// Deterministic correctness tests for the trigger coalescer.
+//
+// Pattern: WaitGroup with exact counts (calculated up front) + the
+// coalescer's own Shutdown(), which internally wg.Wait()s every drainer
+// goroutine — so when Shutdown returns, no further HTTP fires are possible.
+// After Shutdown we assert hit counts (bounded, since coalescing collapses
+// an unspecified number of triggers into ≥1 HTTP calls).
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTriggerCoalescerDeliversAtLeastOnce pins the core invariant: after any
+// number of Trigger calls for a node, that node receives at least one HTTP
+// wake-up. Coalescing collapses bursts but never drops every signal.
+func TestTriggerCoalescerDeliversAtLeastOnce(t *testing.T) {
+	var firstHit sync.WaitGroup
+	firstHit.Add(1)
+	var once sync.Once
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		once.Do(firstHit.Done)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTriggerCoalescer(srv.Client(), nil, nil)
+	addr := srv.Listener.Addr().String()
+
+	for range 100 {
+		c.Trigger(addr, "items/*")
+	}
+
+	firstHit.Wait()
+	c.Shutdown()
+
+	final := atomic.LoadInt32(&hits)
+	require.GreaterOrEqual(t, final, int32(1), "node received no triggers — coalescer dropped them all")
+	require.LessOrEqual(t, final, int32(100), "more triggers than caller signaled — coalescer is amplifying work")
+}
+
+// TestTriggerCoalescerEachNodeGetsAtLeastOne ensures multi-node fan-out
+// reaches every registered node, not just the first one — i.e., per-node
+// drainers are independent.
+func TestTriggerCoalescerEachNodeGetsAtLeastOne(t *testing.T) {
+	const numNodes = 4
+
+	var allFirstHits sync.WaitGroup
+	allFirstHits.Add(numNodes)
+
+	var hits [numNodes]int32
+	var onces [numNodes]sync.Once
+	addrs := make([]string, numNodes)
+
+	for i := range numNodes {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits[i], 1)
+			onces[i].Do(allFirstHits.Done)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+		addrs[i] = srv.Listener.Addr().String()
+	}
+
+	c := newTriggerCoalescer(http.DefaultClient, nil, nil)
+	for i := range 50 {
+		c.Trigger(addrs[i%numNodes], "items/*")
+	}
+
+	allFirstHits.Wait()
+	c.Shutdown()
+
+	for i := range numNodes {
+		require.GreaterOrEqual(t, atomic.LoadInt32(&hits[i]), int32(1),
+			"node %d (%s) received no triggers", i, addrs[i])
+	}
+}
+
+// TestTriggerCoalescerShutdownIdempotent verifies double-Shutdown is safe.
+func TestTriggerCoalescerShutdownIdempotent(t *testing.T) {
+	c := newTriggerCoalescer(http.DefaultClient, nil, nil)
+	c.Shutdown()
+	c.Shutdown() // must not panic on already-closed stop channel
+}
+
+// TestTriggerCoalescerNoTriggersAfterShutdown verifies Trigger calls that
+// arrive after Shutdown are silent no-ops (no HTTP fire, no goroutine spawn).
+func TestTriggerCoalescerNoTriggersAfterShutdown(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTriggerCoalescer(srv.Client(), nil, nil)
+	c.Shutdown() // shut down BEFORE any triggers
+
+	addr := srv.Listener.Addr().String()
+	for range 10 {
+		c.Trigger(addr, "items/*")
+	}
+
+	// Trigger() after Shutdown is synchronous no-op — drainer goroutines have
+	// already exited via wg.Wait() inside Shutdown(). Nothing async to wait
+	// on; if the contract were broken, hits would be > 0.
+	require.Equal(t, int32(0), atomic.LoadInt32(&hits), "trigger after shutdown should not fire HTTP")
+}


### PR DESCRIPTION
## Summary
Closes #28.

The pivot broadcast loop used to spawn one goroutine per event per registered node, each making one HTTP "wake up and pull" request. Under write bursts this collapses into thousands of redundant goroutines and HTTP calls per second across the cluster — the trigger is a wake-up, not data delivery, and 100 wake-ups in quick succession have the same effect as one because the node always pulls *current* state on its next pull.

This PR replaces that fan-out with a per-node coalescer: one drainer goroutine per node, a 1-buffered notify channel, and a per-node pending set of key paths. While the drainer is in the middle of an HTTP call, subsequent triggers accumulate in the set; the drainer's next loop iteration drains them all in one HTTP request. When multiple distinct keys are pending, it falls back to a single `SyncAll` request — the receiver-side handler already supports that.

**Coalescing is timer-free.** No `time.Sleep`, no debounce window, no polling. It emerges from "single consumer plus 1-buffered notify": triggers that arrive while the drainer is busy land in the pending set; the drainer drains them when it's free. This keeps the codebase's deterministic-causal-chain testing model intact — tests use WaitGroup with exact counts and `coalescer.Shutdown()` as a synchronization point.

## Performance

End-to-end measurements against a real pivot with `httptest`-backed nodes (throwaway bench, not committed):

| Scenario | HTTP fires before | After | Reduction |
|---|---:|---:|---:|
| 3 nodes × 20 events | 60 | 7 | 8.6× |
| 5 nodes × 20 events | 100 | 11 | 9.1× |
| 10 nodes × 20 events | 200 | 25 | 8.0× |
| 10 nodes × 50 events | **500** | **22** | **22.7×** |

Coalescing factor scales with burst intensity. Every node still receives at least one trigger — the bench's per-node `minHits == 0` check would fail otherwise.

## Correctness

The contract the coalescer guarantees:
- **Liveness** — after `Trigger(node, key)`, that node receives at least one HTTP fire.
- **Safety** — never amplifies (≤ caller's signal count).
- **Bounded** — exact count is in `[1, N]`, decided by the Go scheduler and burst rate.

The system was already non-deterministic in this dimension (the prior code spawned N goroutines per event but they ran in scheduler order). The cluster's *eventual state* convergence is what's deterministic, and this PR preserves that.

Existing tests are unaffected because they count **data-level events** (storage events, WS broadcasts) — not HTTP triggers. Coalescing changes the latter; data-level event counts hold (a node still applies every distinct item it pulls, each firing its own storage event).

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` 13.7s green
- [x] `go test -race ./...` 14.5s green
- [x] **`go test -race -count=10 ./...` 100s green — no flakiness across 10 race iterations.**
- [x] 4 new deterministic correctness tests using the codebase's WaitGroup pattern:
  - `TestTriggerCoalescerDeliversAtLeastOnce` — 100 triggers → ≥1 and ≤100 HTTP fires.
  - `TestTriggerCoalescerEachNodeGetsAtLeastOne` — 50 round-robin triggers across 4 nodes → each gets ≥1 fire.
  - `TestTriggerCoalescerShutdownIdempotent` — double-Shutdown safe.
  - `TestTriggerCoalescerNoTriggersAfterShutdown` — Trigger after Shutdown is silent no-op.
- [x] All 4 new tests pass under `-race -count=10` in 1.6s.
- [ ] Smoke-test on a real cluster under sync load (operator).

## What's in the diff
```
 instance.go              |   1 +
 pivot.go                 |  10 +++++
 sync.go                  |  19 ++++-----
 trigger.go (new)         | 175 ++++++++++++++++++++++
 trigger_test.go (new)    | 118 ++++++++++++++++
 5 files changed, 309 insertions(+), 14 deletions(-)
```

No public API changes (`triggerCoalescer`, `nodeTrigger`, `newTriggerCoalescer` are all unexported; the new `triggers` field on `Instance` is unexported). No on-disk format changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)