### PR TITLE
fix: skip VV increment when nodeID is unset

### DIFF
--- a/version_vector.go
+++ b/version_vector.go
@@ -208,6 +208,17 @@ func (m *VVManager) increment(keyPath string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	// Node servers create their VVManager with nodeID="" during Setup and only
+	// call SetNodeID once server.Address is known (inside OnStart). The TCP
+	// listener is up before OnStart fires, so storage events can reach this
+	// path with an empty nodeID. Persisting "" would gain a counter no peer
+	// ever increments and live in storage forever. Skip and log loudly so the
+	// regression surfaces if a caller starts incrementing pre-SetNodeID.
+	if m.nodeID == "" {
+		log.Printf("[pivot] VVManager.increment skipped for %q: nodeID not set yet", keyPath)
+		return
+	}
+
 	if _, exists := m.vectors[baseKey]; !exists {
 		m.loadFromStorage(baseKey)
 	}

--- a/version_vector_internal_test.go
+++ b/version_vector_internal_test.go
@@ -67,6 +67,57 @@ func TestVVManagerBasic(t *testing.T) {
 	require.Equal(t, int64(5), vv["nodeA"])
 }
 
+// TestVVManagerIncrementWithEmptyNodeIDDoesNotPollute pins the invariant that
+// increment must refuse to write when nodeID is unset. Node servers construct
+// their VVManager during Setup with nodeID="" and only call SetNodeID once
+// server.Address is known (inside OnStart). The TCP listener is up before
+// OnStart fires, so any storage event reaching makeStorageSync in that window
+// would call increment with an empty nodeID; without this guard the persisted
+// VV gains a "" entry that no peer ever increments and lives forever in
+// storage. Test both the in-memory cache via Get and the on-disk bytes via
+// fresh-manager reload to catch either side regressing.
+func TestVVManagerIncrementWithEmptyNodeIDDoesNotPollute(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+
+	m := NewVVManager(db, "")
+	m.increment("things")
+	m.increment("things")
+
+	vv := m.Get("things")
+	_, hasEmpty := vv[""]
+	require.False(t, hasEmpty, "increment with empty nodeID polluted in-memory VV with '' key: %v", vv)
+
+	// Reload from storage to confirm nothing was persisted under "".
+	reloaded := NewVVManager(db, "")
+	persisted := reloaded.Get("things")
+	_, hasEmpty = persisted[""]
+	require.False(t, hasEmpty, "increment with empty nodeID polluted on-disk VV with '' key: %v", persisted)
+}
+
+// TestVVManagerIncrementResumesAfterSetNodeID verifies the fix doesn't cause
+// permanent loss: once SetNodeID is called with a real address, subsequent
+// increments must work normally.
+func TestVVManagerIncrementResumesAfterSetNodeID(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+
+	m := NewVVManager(db, "")
+	m.increment("things") // dropped — nodeID empty
+	m.SetNodeID("127.0.0.1:9000")
+	m.increment("things")
+	m.increment("things")
+
+	vv := m.Get("things")
+	require.Equal(t, int64(2), vv["127.0.0.1:9000"], "increments after SetNodeID must land on the real node ID")
+	_, hasEmpty := vv[""]
+	require.False(t, hasEmpty, "VV must not carry phantom '' counter after SetNodeID")
+}
+
 func TestVVManagerPersistence(t *testing.T) {
 	monotonic.Init()
 	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})


### PR DESCRIPTION
## Summary
- Closes #30 — node servers no longer write phantom entries to their persisted version vector during the startup window.
- Skipped updates surface as a loud log line so any future regression reintroducing the race shows up immediately rather than silently corrupting persisted state.

## Test plan
- [x] New regression test fails before the change and passes after.
- [x] Companion test verifies vector updates resume normally once node identity is set.
- [x] Full pivot suite green with `-race`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)