### PR TITLE
fix: defer node-to-leader forwards until node identity is known

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -449,7 +449,8 @@ func newSyncerPool(client *http.Client, keys []Key, configClusterURL string, ssl
 	return pool
 }
 
-// SetNodeAddr sets the node address on all syncers
+// SetNodeAddr sets the node address on all syncers and drains anything that
+// was queued while the address was unset (the pre-OnStart startup window).
 func (p *syncerPool) SetNodeAddr(addr string) {
 	p.nodeAddr = addr
 	for _, s := range p.syncers {
@@ -482,9 +483,15 @@ func (p *syncerPool) SyncAll() error {
 	return lastErr
 }
 
-// SetNodeAddr sets the node's address (called after server starts)
+// SetNodeAddr sets the node's address (called after server starts) and drains
+// any operations that were queued while nodeAddr was empty (the pre-OnStart
+// startup window). Drained ops are sent with the correct originator so the
+// leader can identify and skip this node when fanning the change out.
 func (s *syncer) SetNodeAddr(addr string) {
+	s.queueMu.Lock()
 	s.nodeAddr = addr
+	s.queueMu.Unlock()
+	s.drainQueue()
 }
 
 // Pull syncs FROM pivot only (used when pivot notifies node of changes)
@@ -663,54 +670,57 @@ func (s *syncer) PullKey(keyPath string) error {
 	return err
 }
 
-// processQueue sends all queued per-key operations to leader
-func (s *syncer) processQueue() {
+// drainQueue snapshots the pending queue and the current nodeAddr under
+// queueMu, then sends each op outside the lock. Returns immediately if
+// nodeAddr is unset (we're still in the pre-OnStart startup window) so the
+// queued ops wait for SetNodeAddr to drain them with the correct originator.
+func (s *syncer) drainQueue() {
 	s.queueMu.Lock()
-	if len(s.queue) == 0 {
+	if s.nodeAddr == "" || len(s.queue) == 0 {
 		s.queueMu.Unlock()
 		return
 	}
-	// Take ownership of the queue
+	addr := s.nodeAddr
 	pending := s.queue
 	s.queue = make([]pendingOp, 0)
 	s.queueMu.Unlock()
 
-	// Process each operation
 	for _, op := range pending {
 		switch op.opType {
 		case "set":
-			sendToLeader(s.ClientOpts(), op.key, op.obj, s.nodeAddr)
+			sendToLeader(s.ClientOpts(), op.key, op.obj, addr)
 		case "del":
-			sendDeleteToLeader(s.ClientOpts(), op.key, op.ts, s.nodeAddr)
+			sendDeleteToLeader(s.ClientOpts(), op.key, op.ts, addr)
 		}
 	}
+}
+
+// processQueue sends all queued per-key operations to leader
+func (s *syncer) processQueue() {
+	s.drainQueue()
 }
 
 // processQueueLocked sends all queued per-key operations to leader (caller must hold s.mu)
 func (s *syncer) processQueueLocked() {
+	s.drainQueue()
+}
+
+// QueueOrSendSet sends a set operation to leader, or queues it if Pull is in
+// progress or the syncer's nodeAddr hasn't been set yet (pre-OnStart startup
+// window). The queue is drained by the next Pull completion or by
+// SetNodeAddr, whichever comes first.
+func (s *syncer) QueueOrSendSet(key string, obj meta.Object) {
 	s.queueMu.Lock()
-	if len(s.queue) == 0 {
+	if s.nodeAddr == "" {
+		s.queue = append(s.queue, pendingOp{opType: "set", key: key, obj: obj})
 		s.queueMu.Unlock()
 		return
 	}
-	pending := s.queue
-	s.queue = make([]pendingOp, 0)
+	addr := s.nodeAddr
 	s.queueMu.Unlock()
 
-	for _, op := range pending {
-		switch op.opType {
-		case "set":
-			sendToLeader(s.ClientOpts(), op.key, op.obj, s.nodeAddr)
-		case "del":
-			sendDeleteToLeader(s.ClientOpts(), op.key, op.ts, s.nodeAddr)
-		}
-	}
-}
-
-// QueueOrSendSet sends a set operation to leader, or queues it if Pull is in progress
-func (s *syncer) QueueOrSendSet(key string, obj meta.Object) {
 	if s.mu.TryLock() {
-		sendToLeader(s.ClientOpts(), key, obj, s.nodeAddr)
+		sendToLeader(s.ClientOpts(), key, obj, addr)
 		s.mu.Unlock()
 	} else {
 		// Pull in progress - queue for later and wait for Pull to complete then process
@@ -724,10 +734,21 @@ func (s *syncer) QueueOrSendSet(key string, obj meta.Object) {
 	}
 }
 
-// QueueOrSendDelete sends a delete operation to leader, or queues it if Pull is in progress
+// QueueOrSendDelete sends a delete operation to leader, or queues it if Pull
+// is in progress or the syncer's nodeAddr hasn't been set yet (pre-OnStart
+// startup window).
 func (s *syncer) QueueOrSendDelete(key string, ts int64) {
+	s.queueMu.Lock()
+	if s.nodeAddr == "" {
+		s.queue = append(s.queue, pendingOp{opType: "del", key: key, ts: ts})
+		s.queueMu.Unlock()
+		return
+	}
+	addr := s.nodeAddr
+	s.queueMu.Unlock()
+
 	if s.mu.TryLock() {
-		sendDeleteToLeader(s.ClientOpts(), key, ts, s.nodeAddr)
+		sendDeleteToLeader(s.ClientOpts(), key, ts, addr)
 		s.mu.Unlock()
 	} else {
 		// Pull in progress - queue for later and wait for Pull to complete then process
@@ -741,11 +762,22 @@ func (s *syncer) QueueOrSendDelete(key string, ts int64) {
 	}
 }
 
-// Sync performs bidirectional synchronization with tracking
+// Sync performs bidirectional synchronization with tracking. Returns nil
+// without contacting the leader if nodeAddr is unset (pre-OnStart startup
+// window) — sending with empty Originator would prevent the leader from
+// skipping this node when fanning the change out, producing a self-trigger
+// echo. Reachable callers (AutoSyncOnStart, /synchronize/node) re-trigger
+// after OnStart, so skipping here is safe.
 func (s *syncer) Sync() error {
+	s.queueMu.Lock()
+	addr := s.nodeAddr
+	s.queueMu.Unlock()
+	if addr == "" {
+		return nil
+	}
 	s.mu.Lock()
 	opts := SyncOptions{
-		Originator:     s.nodeAddr,
+		Originator:     addr,
 		IsRecentDelete: s.tracker.pulledDelete,
 		OnDelete:       s.tracker.trackDelete,
 		OnSet:          s.tracker.trackSet,

--- a/syncer_init_test.go
+++ b/syncer_init_test.go
@@ -1,0 +1,143 @@
+package pivot
+
+// Internal-package test for the syncer's pre-init startup window.
+//
+// Race window: in ooo's StartWithError, waitListen sets server.Address and
+// flips active=1 (line 347), then wg.Done() releases StartWithError, which
+// continues to call OnStart() at line 682. pivot.Setup wires SetNodeAddr into
+// OnStart, so between listener-up and OnStart-firing the syncer carries
+// nodeAddr="". Any storage event in that window calls QueueOrSendSet/Delete,
+// which without this guard sends to the leader with no X-Pivot-Originator —
+// the leader can't identify this node, fans the change back to it, and
+// produces a self-trigger echo (and on every retry, no skip).
+//
+// Pattern: drive the syncer directly with empty nodeAddr — same shape as the
+// VVManager test added in #31. WaitGroup-based synchronization, no sleeps.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/benitogf/ooo/meta"
+	"github.com/benitogf/ooo/monotonic"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeLeader records the originator header from any inbound POST/DELETE and
+// signals first-hit via a WaitGroup so tests synchronise without time.Sleep.
+type fakeLeader struct {
+	srv      *httptest.Server
+	hits     int32
+	firstHit sync.WaitGroup
+	once     sync.Once
+
+	mu             sync.Mutex
+	lastOriginator string
+	allOriginators []string
+}
+
+func newFakeLeader() *fakeLeader {
+	l := &fakeLeader{}
+	l.firstHit.Add(1)
+	l.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&l.hits, 1)
+		orig := r.Header.Get(OriginatorHeader)
+		l.mu.Lock()
+		l.lastOriginator = orig
+		l.allOriginators = append(l.allOriginators, orig)
+		l.mu.Unlock()
+		l.once.Do(l.firstHit.Done)
+		w.WriteHeader(http.StatusOK)
+	}))
+	return l
+}
+
+func (l *fakeLeader) addr() string { return l.srv.URL[len("http://"):] }
+func (l *fakeLeader) close()       { l.srv.Close() }
+
+func (l *fakeLeader) hitCount() int32 { return atomic.LoadInt32(&l.hits) }
+
+func (l *fakeLeader) originators() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.allOriginators))
+	copy(out, l.allOriginators)
+	return out
+}
+
+// TestSyncerDefersSendUntilNodeAddrSet pins the bug: a syncer constructed with
+// empty nodeAddr (mirroring pre-OnStart state) must not push to the leader
+// with an empty X-Pivot-Originator. Once SetNodeAddr fires, the queued op
+// must drain with the correct originator.
+func TestSyncerDefersSendUntilNodeAddrSet(t *testing.T) {
+	monotonic.Init()
+	leader := newFakeLeader()
+	defer leader.close()
+
+	s := newSyncer(leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false)
+
+	now := monotonic.Now()
+	obj := meta.Object{
+		Created: now,
+		Updated: now,
+		Index:   "abc",
+		Path:    "things/abc",
+		Data:    []byte(`{"v":1}`),
+	}
+
+	// Pre-init: nodeAddr is "". A storage-event-driven send must not reach the
+	// leader yet — it must be deferred until the addr is known.
+	s.QueueOrSendSet("things/abc", obj)
+
+	// Now fire SetNodeAddr; the deferred op must drain with the correct
+	// originator.
+	const nodeAddr = "127.0.0.1:9001"
+	s.SetNodeAddr(nodeAddr)
+
+	leader.firstHit.Wait()
+
+	require.Equal(t, nodeAddr, leader.originators()[0],
+		"leader received request with wrong X-Pivot-Originator (originators seen: %v)", leader.originators())
+}
+
+// TestSyncerDefersDeleteUntilNodeAddrSet — same invariant for delete ops.
+func TestSyncerDefersDeleteUntilNodeAddrSet(t *testing.T) {
+	monotonic.Init()
+	leader := newFakeLeader()
+	defer leader.close()
+
+	s := newSyncer(leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false)
+
+	s.QueueOrSendDelete("things/abc", monotonic.Now())
+
+	const nodeAddr = "127.0.0.1:9002"
+	s.SetNodeAddr(nodeAddr)
+
+	leader.firstHit.Wait()
+
+	require.Equal(t, nodeAddr, leader.originators()[0],
+		"leader received delete with wrong X-Pivot-Originator (originators seen: %v)", leader.originators())
+}
+
+// TestSyncerSendsImmediatelyAfterNodeAddrSet — once nodeAddr is set,
+// QueueOrSendSet should send synchronously (not buffer indefinitely).
+func TestSyncerSendsImmediatelyAfterNodeAddrSet(t *testing.T) {
+	monotonic.Init()
+	leader := newFakeLeader()
+	defer leader.close()
+
+	s := newSyncer(leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false)
+	const nodeAddr = "127.0.0.1:9003"
+	s.SetNodeAddr(nodeAddr)
+
+	now := monotonic.Now()
+	obj := meta.Object{Created: now, Updated: now, Index: "abc", Path: "things/abc", Data: []byte(`{"v":1}`)}
+	s.QueueOrSendSet("things/abc", obj)
+
+	leader.firstHit.Wait()
+	require.Equal(t, nodeAddr, leader.originators()[0])
+	require.Equal(t, int32(1), leader.hitCount())
+}


### PR DESCRIPTION
## Summary
- Closes #32 — writes that fire during a node's startup window are now buffered and forwarded once the node's address is known, with the correct sender identification so the leader can skip this node when fanning the change out.
- Skipping the buffered drain is safe when the address is still unknown — the next address-set event triggers the drain, and any startup-time pull-from-leader path is similarly held until the node can identify itself.

## Test plan
- [x] New regression tests fail before the change and pass after — both write and delete paths covered.
- [x] Companion test verifies the post-startup direct-send path continues to work.
- [x] Full pivot suite green at `-race -count=3`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)