### PR TITLE
fix: detect cluster-leader change when storage opens during startup

### DIFF
--- a/cluster_url_change_test.go
+++ b/cluster_url_change_test.go
@@ -1,0 +1,130 @@
+package pivot_test
+
+// Regression test for the bug where checkClusterURLChange ran at Setup time
+// and silently no-op'd when storage wasn't yet active. With memory-backed
+// embedded storage (storage activates inside server.Start, not before), the
+// wipe-on-cluster-URL-change protection was bypassed entirely:
+//   - Round 1 Setup: storage inactive → check no-op → URL fingerprint never
+//     persisted to storage.
+//   - Round 1 server.Start: storage activates, but nothing re-runs the check.
+//   - Round 1 Close: persisted state has user data, no URL fingerprint.
+//   - Round 2 Setup with a different ClusterURL: storage inactive → no-op.
+//   - Round 2 server.Start: storage activates, but the (still missing) check
+//     never runs. Stale data from leaderA stays mixed with whatever leaderB
+//     pushes.
+//
+// After the fix, checkClusterURLChange runs from inside the OnStart wrapper
+// once storage is guaranteed active. It also encodes the persisted URL as a
+// JSON string (the storage layer treats values as json.RawMessage; raw
+// host:port bytes aren't valid JSON, so the prior format silently failed to
+// round-trip on reload regardless of when the function ran).
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/benitogf/ko"
+	"github.com/benitogf/ooo"
+	"github.com/benitogf/ooo/monotonic"
+	"github.com/benitogf/ooo/storage"
+	"github.com/benitogf/pivot"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+// runRound boots a fresh server with the given embedded storage path and
+// cluster URL, optionally writes a payload, then closes the server.
+func runRound(t *testing.T, dbPath, clusterURL string, write func(storage.Database)) {
+	t.Helper()
+	embedded := &ko.EmbeddedStorage{Path: dbPath}
+	dataStorage := storage.New(storage.LayeredConfig{
+		Memory:   storage.NewMemoryLayer(),
+		Embedded: embedded,
+	})
+	server := &ooo.Server{
+		Silence: true,
+		Static:  true,
+		Storage: dataStorage,
+		Router:  mux.NewRouter(),
+	}
+	server = pivot.Setup(server, pivot.Config{
+		Keys: []pivot.Key{
+			{Path: "items/*"},
+		},
+		NodesKey:            "devices/*",
+		ClusterURL:          clusterURL,
+		AutoSyncOnStart:     false, // no leader to sync with; we just want the URL-change protection
+		HealthCheckInterval: time.Hour,
+		SyncRetryInterval:   time.Hour,
+	})
+
+	// The storage must NOT be pre-started — that's the whole point of the bug.
+	require.False(t, dataStorage.Active(), "test precondition: storage must be inactive at this point")
+
+	server.Start("127.0.0.1:0")
+
+	if write != nil {
+		write(dataStorage)
+	}
+
+	server.Close(os.Interrupt)
+}
+
+func TestClusterURLChangeWipesAfterRestartWithChangedURL(t *testing.T) {
+	monotonic.Init()
+	dbPath := fmt.Sprintf("test/cluster_url_change_%d", time.Now().UnixNano())
+	defer os.RemoveAll(dbPath)
+
+	// Round 1: come up against leaderA, write some user data, shut down.
+	runRound(t, dbPath, "127.0.0.1:19111", func(db storage.Database) {
+		_, err := db.Set("items/x", []byte(`{"v":1}`))
+		require.NoError(t, err, "round 1: write user data while storage active")
+	})
+
+	// Sanity: the user data persisted across the close. If even items/x is
+	// missing, something deeper is wrong with embedded persistence and the
+	// rest of the test would fail for the wrong reason.
+	{
+		embedded := &ko.EmbeddedStorage{Path: dbPath}
+		probe := storage.New(storage.LayeredConfig{
+			Memory:   storage.NewMemoryLayer(),
+			Embedded: embedded,
+		})
+		require.NoError(t, probe.Start(storage.Options{}))
+		obj, err := probe.Get("items/x")
+		require.NoError(t, err, "between rounds: items/x must persist across close — embedded storage issue if not")
+		require.NotEmpty(t, obj.Data)
+		probe.Close()
+	}
+
+	// Round 2: come up against leaderB (different URL). The cluster-URL change
+	// detection must wipe items/* before this round's normal operation begins.
+	runRound(t, dbPath, "127.0.0.1:19222", func(db storage.Database) {
+		_, err := db.Get("items/x")
+		require.Error(t, err, "round 2: items/x must be wiped because cluster URL changed (was leaderA, now leaderB)")
+	})
+}
+
+// TestClusterURLChangeNoWipeOnSameURL asserts the inverse: the wipe must NOT
+// fire when the cluster URL is unchanged across restarts. Otherwise we'd
+// destroy data on every routine restart.
+func TestClusterURLChangeNoWipeOnSameURL(t *testing.T) {
+	monotonic.Init()
+	dbPath := fmt.Sprintf("test/cluster_url_unchanged_%d", time.Now().UnixNano())
+	defer os.RemoveAll(dbPath)
+
+	const sameURL = "127.0.0.1:19333"
+
+	runRound(t, dbPath, sameURL, func(db storage.Database) {
+		_, err := db.Set("items/y", []byte(`{"v":2}`))
+		require.NoError(t, err)
+	})
+
+	runRound(t, dbPath, sameURL, func(db storage.Database) {
+		obj, err := db.Get("items/y")
+		require.NoError(t, err, "items/y must persist across restart with unchanged cluster URL")
+		require.NotEmpty(t, obj.Data)
+	})
+}

--- a/pivot.go
+++ b/pivot.go
@@ -345,12 +345,9 @@ func checkClusterURLChange(server *ooo.Server, config Config, configClusterURL s
 		baseKey := baseKeyFromPath(k.Path)
 		storageKey := pivotURLKeyPrefix + baseKey
 
-		// Read stored pivot URL for this key
-		obj, err := server.Storage.Get(storageKey)
-		storedURL := ""
-		if err == nil {
-			storedURL = string(obj.Data)
-		}
+		// Read stored pivot URL for this key. Persisted as a JSON-quoted
+		// string so the storage layer's json.RawMessage round-trip succeeds.
+		storedURL := readURLFingerprint(server.Storage, storageKey)
 
 		if storedURL != "" && storedURL != effectiveURL {
 			log.Printf("WARNING: Pivot URL for key %q changed from %q to %q - wiping data", k.Path, storedURL, effectiveURL)
@@ -362,8 +359,17 @@ func checkClusterURLChange(server *ooo.Server, config Config, configClusterURL s
 			wiped = true
 		}
 
-		// Store/update the effective pivot URL for this key
-		server.Storage.Set(storageKey, []byte(effectiveURL))
+		// Store/update the effective pivot URL for this key. The value goes
+		// through the storage layer's json.RawMessage round-trip, so it must
+		// be valid JSON — store as a quoted JSON string, not as raw bytes.
+		encoded, err := json.Marshal(effectiveURL)
+		if err != nil {
+			log.Printf("[pivot] failed to encode URL fingerprint for %q: %v", k.Path, err)
+			continue
+		}
+		if _, err := server.Storage.Set(storageKey, encoded); err != nil {
+			log.Printf("[pivot] failed to persist URL fingerprint for %q: %v", k.Path, err)
+		}
 	}
 
 	// Also check NodesKey (always uses configClusterURL)
@@ -371,11 +377,7 @@ func checkClusterURLChange(server *ooo.Server, config Config, configClusterURL s
 		// Use base key (without wildcard) for storage key
 		baseKey := baseKeyFromPath(config.NodesKey)
 		storageKey := pivotURLKeyPrefix + baseKey
-		obj, err := server.Storage.Get(storageKey)
-		storedURL := ""
-		if err == nil {
-			storedURL = string(obj.Data)
-		}
+		storedURL := readURLFingerprint(server.Storage, storageKey)
 
 		if storedURL != "" && storedURL != configClusterURL {
 			log.Printf("WARNING: Pivot URL for NodesKey %q changed from %q to %q - wiping data", config.NodesKey, storedURL, configClusterURL)
@@ -383,10 +385,34 @@ func checkClusterURLChange(server *ooo.Server, config Config, configClusterURL s
 			wiped = true
 		}
 
-		server.Storage.Set(storageKey, []byte(configClusterURL))
+		encoded, err := json.Marshal(configClusterURL)
+		if err != nil {
+			log.Printf("[pivot] failed to encode URL fingerprint for NodesKey %q: %v", config.NodesKey, err)
+		} else if _, err := server.Storage.Set(storageKey, encoded); err != nil {
+			log.Printf("[pivot] failed to persist URL fingerprint for NodesKey %q: %v", config.NodesKey, err)
+		}
 	}
 
 	return wiped
+}
+
+// readURLFingerprint reads a persisted pivot URL fingerprint. The on-disk
+// format is a JSON-quoted string (so it survives the storage layer's
+// json.RawMessage round-trip); a missing or unparseable entry yields the
+// empty string, which the caller treats as "no prior fingerprint".
+func readURLFingerprint(db storage.Database, storageKey string) string {
+	obj, err := db.Get(storageKey)
+	if err != nil {
+		return ""
+	}
+	var url string
+	if err := json.Unmarshal(obj.Data, &url); err != nil {
+		// Pre-existing data written with the broken raw-bytes format will
+		// fail to decode; treat as no fingerprint, the next write replaces
+		// it with the correct format.
+		return ""
+	}
+	return url
 }
 
 // wipeStorage deletes all entries matching the given path pattern
@@ -449,7 +475,13 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 		client = defaultClient()
 	}
 
-	// Check if pivot IP changed since last run - wipe data if so
+	// Run the wipe-on-cluster-URL-change check immediately when storage is
+	// already active (e.g. user pre-started embedded storage before calling
+	// Setup). Doing it here lets the wipe's storage events run before the
+	// user has had a chance to wrap server.OnStorageEvent post-Setup, so
+	// downstream test/observer code only sees events for *intentional*
+	// writes. The OnStart wrapper below covers the deferred case where
+	// storage activates inside server.Start.
 	checkClusterURLChange(server, config, pivotURL)
 
 	keys := buildKeys(server, config)
@@ -698,6 +730,20 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 					server.Console.Log("pivot: initial sync completed successfully")
 				}
 			}
+		}
+	}
+
+	// Run the wipe-on-cluster-URL-change check from OnStart so it executes
+	// once storage is guaranteed active (memory-backed storages activate
+	// inside server.Start, not before). Wraps the outermost OnStart so the
+	// wipe runs before SetNodeAddr / SetNodeID / AutoSyncOnStart from the
+	// node-startup wrapper above. Idempotent across restarts: a second
+	// invocation reads the URL it just persisted and is a no-op.
+	clusterURLCheckExisting := server.OnStart
+	server.OnStart = func() {
+		checkClusterURLChange(server, config, pivotURL)
+		if clusterURLCheckExisting != nil {
+			clusterURLCheckExisting()
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Closes #34 — the wipe-on-leader-change protection now runs reliably regardless of whether the on-disk store is opened before or during pivot configuration.
- The persisted URL fingerprint that drives the comparison now round-trips correctly to disk and back; previously it was written in a format the storage layer couldn't reload, so the comparison never had real prior state to work with.
- Persistence failures now surface in logs rather than silently dropping the write.

## Test plan
- [x] Regression test boots a node against leader A, writes data, restarts against leader B, and asserts the data is wiped — fails before the change and passes after.
- [x] Companion test verifies an unchanged leader across restarts does NOT trigger a wipe (the inverse invariant).
- [x] Full pivot suite green at `-race -count=3`. The hermit-crab tests, which exercise the leader-switch flow with manually-prestarted storage, continue to pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)