### PR TITLE
fix(handlers): VV bump exactly once after storage write, with synchronous fanout

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -102,14 +102,21 @@ func Set(db storage.Database, path string, originatorTracker *OriginatorTracker,
 		if originatorTracker != nil {
 			originatorTracker.Set(itemKey, r.Header.Get(OriginatorHeader))
 		}
-		// Increment version vector on pivot before storage write
-		if vvManager != nil {
-			vvManager.increment(itemKey)
-		}
 		_, err = db.SetWithMeta(itemKey, decoded.Data, decoded.Created, decoded.Updated)
 		if err != nil {
+			// Drop the originator entry so it doesn't leak across requests.
+			if originatorTracker != nil {
+				originatorTracker.Get(itemKey)
+			}
 			w.WriteHeader(http.StatusInternalServerError)
 			return
+		}
+		// VV bump happens after a successful storage write so the on-disk VV
+		// can never advance past data that wasn't written. The bump is the
+		// sole source of truth for VV — the storage event callback used to
+		// also bump here, which produced a 2× counter on every HTTP write.
+		if vvManager != nil {
+			vvManager.increment(itemKey)
 		}
 		w.WriteHeader(http.StatusOK)
 	}
@@ -134,10 +141,6 @@ func Delete(db storage.Database, path string, originatorTracker *OriginatorTrack
 		if originatorTracker != nil {
 			originatorTracker.Set(itemKey, r.Header.Get(OriginatorHeader))
 		}
-		// Increment version vector on pivot before storage write
-		if vvManager != nil {
-			vvManager.increment(itemKey)
-		}
 		// Tombstone first, then Del. The reverse order leaves a window where
 		// the item is physically gone but no tombstone records the delete; a
 		// crash, context-cancel, or storage error in that window lets the next
@@ -145,13 +148,25 @@ func Delete(db storage.Database, path string, originatorTracker *OriginatorTrack
 		// delete and silently resurrect it. Writing the tombstone first means
 		// the worst case is an orphan tombstone, which sync resolves correctly.
 		if _, err := db.Set(StoragePrefix+path, json.RawMessage(time)); err != nil {
+			if originatorTracker != nil {
+				originatorTracker.Get(itemKey)
+			}
 			log.Printf("[pivot] Delete tombstone write failed for %q: %v", path, err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		if err := db.Del(itemKey); err != nil {
+			if originatorTracker != nil {
+				originatorTracker.Get(itemKey)
+			}
 			w.WriteHeader(http.StatusInternalServerError)
 			return
+		}
+		// VV bump after both storage writes succeeded — the on-disk VV can
+		// never advance past data that wasn't written. Single source of truth;
+		// the storage callback no longer increments here.
+		if vvManager != nil {
+			vvManager.increment(itemKey)
 		}
 		w.WriteHeader(http.StatusOK)
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -83,10 +83,20 @@ func GetSingle(db storage.Database, path string) func(w http.ResponseWriter, r *
 	}
 }
 
+// PostWriteFunc is called by Set/Delete handlers after a successful local
+// write to propagate the change. On pivot servers it triggers the matched
+// peer nodes (skipping the originating peer); on node servers it pushes
+// the change to the pivot leader. Running this synchronously after the
+// VV bump (rather than from the async storage event callback) means a
+// peer woken by the trigger sees the bumped VV, not a stale one.
+type PostWriteFunc func(itemKey, op, originatorPeer string)
+
 // Set set data on the pivot instance
 // originatorTracker is used to track which node originated the change (for pivot servers)
 // vvManager is the version vector manager for pivot servers (nil for nodes)
-func Set(db storage.Database, path string, originatorTracker *OriginatorTracker, vvManager *VVManager) func(w http.ResponseWriter, r *http.Request) {
+// postWrite, if non-nil, runs synchronously after a successful VV bump to
+// fan out the change to peers. May be nil in tests that don't need fanout.
+func Set(db storage.Database, path string, originatorTracker *OriginatorTracker, vvManager *VVManager, postWrite PostWriteFunc) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		decoded, err := meta.DecodeFromReader(r.Body)
 		if err != nil {
@@ -98,25 +108,33 @@ func Set(db storage.Database, path string, originatorTracker *OriginatorTracker,
 		if index == "" {
 			itemKey = path
 		}
-		// Track originator before storage write so callback can exclude it from TriggerNodeSync
+		// Track originator before storage write so the storage callback's
+		// dedup signal is in place by the time the watch goroutine processes
+		// the event. The header value is also kept locally so the post-write
+		// fanout can skip the originating peer.
+		originatorPeer := r.Header.Get(OriginatorHeader)
 		if originatorTracker != nil {
-			originatorTracker.Set(itemKey, r.Header.Get(OriginatorHeader))
+			originatorTracker.Set(itemKey, originatorPeer)
 		}
 		_, err = db.SetWithMeta(itemKey, decoded.Data, decoded.Created, decoded.Updated)
 		if err != nil {
 			// Drop the originator entry so it doesn't leak across requests.
 			if originatorTracker != nil {
-				originatorTracker.Get(itemKey)
+				originatorTracker.Take(itemKey)
 			}
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		// VV bump happens after a successful storage write so the on-disk VV
-		// can never advance past data that wasn't written. The bump is the
-		// sole source of truth for VV — the storage event callback used to
-		// also bump here, which produced a 2× counter on every HTTP write.
+		// VV bump after a successful storage write so the on-disk VV can
+		// never advance past data that wasn't written. The bump must
+		// complete BEFORE we trigger peers — otherwise a peer woken by the
+		// trigger could read /activity and see the pre-bump VV, conclude
+		// it's up to date, and skip the pull.
 		if vvManager != nil {
 			vvManager.increment(itemKey)
+		}
+		if postWrite != nil {
+			postWrite(itemKey, "set", originatorPeer)
 		}
 		w.WriteHeader(http.StatusOK)
 	}
@@ -125,7 +143,8 @@ func Set(db storage.Database, path string, originatorTracker *OriginatorTracker,
 // Delete delete data on the pivot instance
 // originatorTracker is used to track which node originated the change (for pivot servers)
 // vvManager is the version vector manager for pivot servers (nil for nodes)
-func Delete(db storage.Database, path string, originatorTracker *OriginatorTracker, vvManager *VVManager) func(w http.ResponseWriter, r *http.Request) {
+// postWrite mirrors Set's parameter — runs after VV bump to fan out the change.
+func Delete(db storage.Database, path string, originatorTracker *OriginatorTracker, vvManager *VVManager, postWrite PostWriteFunc) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		index := mux.Vars(r)["index"]
 		time := mux.Vars(r)["time"]
@@ -137,9 +156,9 @@ func Delete(db storage.Database, path string, originatorTracker *OriginatorTrack
 			// Glob pattern delete (e.g., "things/123")
 			itemKey = path + "/" + index
 		}
-		// Track originator before storage write so callback can exclude it from TriggerNodeSync
+		originatorPeer := r.Header.Get(OriginatorHeader)
 		if originatorTracker != nil {
-			originatorTracker.Set(itemKey, r.Header.Get(OriginatorHeader))
+			originatorTracker.Set(itemKey, originatorPeer)
 		}
 		// Tombstone first, then Del. The reverse order leaves a window where
 		// the item is physically gone but no tombstone records the delete; a
@@ -149,7 +168,7 @@ func Delete(db storage.Database, path string, originatorTracker *OriginatorTrack
 		// the worst case is an orphan tombstone, which sync resolves correctly.
 		if _, err := db.Set(StoragePrefix+path, json.RawMessage(time)); err != nil {
 			if originatorTracker != nil {
-				originatorTracker.Get(itemKey)
+				originatorTracker.Take(itemKey)
 			}
 			log.Printf("[pivot] Delete tombstone write failed for %q: %v", path, err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -157,16 +176,18 @@ func Delete(db storage.Database, path string, originatorTracker *OriginatorTrack
 		}
 		if err := db.Del(itemKey); err != nil {
 			if originatorTracker != nil {
-				originatorTracker.Get(itemKey)
+				originatorTracker.Take(itemKey)
 			}
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		// VV bump after both storage writes succeeded — the on-disk VV can
-		// never advance past data that wasn't written. Single source of truth;
-		// the storage callback no longer increments here.
+		// VV bump after both storage writes succeeded; bump must precede the
+		// post-write trigger so a peer woken by the trigger reads a fresh VV.
 		if vvManager != nil {
 			vvManager.increment(itemKey)
+		}
+		if postWrite != nil {
+			postWrite(itemKey, "del", originatorPeer)
 		}
 		w.WriteHeader(http.StatusOK)
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -92,11 +92,13 @@ func GetSingle(db storage.Database, path string) func(w http.ResponseWriter, r *
 type PostWriteFunc func(itemKey, op, originatorPeer string)
 
 // Set set data on the pivot instance
-// originatorTracker is used to track which node originated the change (for pivot servers)
-// vvManager is the version vector manager for pivot servers (nil for nodes)
+// handlerTracker records "a handler will own the post-write work for this
+// key" so the async storage callback skips its bump+fanout for this event;
+// the handler does both, in order, after the storage write succeeds.
+// vvManager is the version vector manager for pivot servers (nil for nodes).
 // postWrite, if non-nil, runs synchronously after a successful VV bump to
 // fan out the change to peers. May be nil in tests that don't need fanout.
-func Set(db storage.Database, path string, originatorTracker *OriginatorTracker, vvManager *VVManager, postWrite PostWriteFunc) func(w http.ResponseWriter, r *http.Request) {
+func Set(db storage.Database, path string, handlerTracker *HandlerWriteTracker, vvManager *VVManager, postWrite PostWriteFunc) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		decoded, err := meta.DecodeFromReader(r.Body)
 		if err != nil {
@@ -108,19 +110,22 @@ func Set(db storage.Database, path string, originatorTracker *OriginatorTracker,
 		if index == "" {
 			itemKey = path
 		}
-		// Track originator before storage write so the storage callback's
-		// dedup signal is in place by the time the watch goroutine processes
-		// the event. The header value is also kept locally so the post-write
-		// fanout can skip the originating peer.
+		// Mark before the storage write so the dedup signal is in place
+		// by the time the watch goroutine processes the event. The
+		// originator header is captured locally for the post-write fanout
+		// to skip echoing back to the peer that drove this request.
 		originatorPeer := r.Header.Get(OriginatorHeader)
-		if originatorTracker != nil {
-			originatorTracker.Set(itemKey, originatorPeer)
+		if handlerTracker != nil {
+			handlerTracker.Mark(itemKey)
 		}
 		_, err = db.SetWithMeta(itemKey, decoded.Data, decoded.Created, decoded.Updated)
 		if err != nil {
-			// Drop the originator entry so it doesn't leak across requests.
-			if originatorTracker != nil {
-				originatorTracker.Take(itemKey)
+			// Drop the mark so it doesn't survive across requests — Layered.Set
+			// fires the event even on inner-layer rejection, so the callback
+			// will see and consume our mark; if it doesn't (wrapper rejection
+			// before Layered, like in failingItemStorage), Unmark prevents leak.
+			if handlerTracker != nil {
+				handlerTracker.Unmark(itemKey)
 			}
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -141,10 +146,13 @@ func Set(db storage.Database, path string, originatorTracker *OriginatorTracker,
 }
 
 // Delete delete data on the pivot instance
-// originatorTracker is used to track which node originated the change (for pivot servers)
-// vvManager is the version vector manager for pivot servers (nil for nodes)
-// postWrite mirrors Set's parameter — runs after VV bump to fan out the change.
-func Delete(db storage.Database, path string, originatorTracker *OriginatorTracker, vvManager *VVManager, postWrite PostWriteFunc) func(w http.ResponseWriter, r *http.Request) {
+// handlerTracker / vvManager / postWrite mirror Set's parameters.
+//
+// This handler issues TWO storage writes (tombstone + Del), each of which
+// fires its own storage event. We Mark twice so the callback consumes
+// once per event and skips both, then Unmark on any failure path so
+// stale marks don't leak.
+func Delete(db storage.Database, path string, handlerTracker *HandlerWriteTracker, vvManager *VVManager, postWrite PostWriteFunc) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		index := mux.Vars(r)["index"]
 		time := mux.Vars(r)["time"]
@@ -157,8 +165,11 @@ func Delete(db storage.Database, path string, originatorTracker *OriginatorTrack
 			itemKey = path + "/" + index
 		}
 		originatorPeer := r.Header.Get(OriginatorHeader)
-		if originatorTracker != nil {
-			originatorTracker.Set(itemKey, originatorPeer)
+		// One mark per storage event we'll fire below.
+		tombstoneKey := StoragePrefix + path
+		if handlerTracker != nil {
+			handlerTracker.Mark(tombstoneKey)
+			handlerTracker.Mark(itemKey)
 		}
 		// Tombstone first, then Del. The reverse order leaves a window where
 		// the item is physically gone but no tombstone records the delete; a
@@ -166,17 +177,20 @@ func Delete(db storage.Database, path string, originatorTracker *OriginatorTrack
 		// sync round re-fetch the item from a node that hasn't observed the
 		// delete and silently resurrect it. Writing the tombstone first means
 		// the worst case is an orphan tombstone, which sync resolves correctly.
-		if _, err := db.Set(StoragePrefix+path, json.RawMessage(time)); err != nil {
-			if originatorTracker != nil {
-				originatorTracker.Take(itemKey)
+		if _, err := db.Set(tombstoneKey, json.RawMessage(time)); err != nil {
+			if handlerTracker != nil {
+				handlerTracker.Unmark(tombstoneKey)
+				handlerTracker.Unmark(itemKey)
 			}
 			log.Printf("[pivot] Delete tombstone write failed for %q: %v", path, err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		if err := db.Del(itemKey); err != nil {
-			if originatorTracker != nil {
-				originatorTracker.Take(itemKey)
+			// tombstone Mark was already consumed by the tombstone-Set event;
+			// only itemKey's mark is still pending.
+			if handlerTracker != nil {
+				handlerTracker.Unmark(itemKey)
 			}
 			w.WriteHeader(http.StatusInternalServerError)
 			return

--- a/handlers.go
+++ b/handlers.go
@@ -120,13 +120,12 @@ func Set(db storage.Database, path string, handlerTracker *HandlerWriteTracker, 
 		}
 		_, err = db.SetWithMeta(itemKey, decoded.Data, decoded.Created, decoded.Updated)
 		if err != nil {
-			// Layered.Set returns errors only for input validation
-			// (ErrInvalidPath / ErrInvalidStorageData) — those paths suppress
-			// the event entirely, so our Mark would never be Consumed and
-			// would accumulate. Wrapper-level rejections (failingItemStorage
-			// in tests, custom Database wrappers in real use) also short-
-			// circuit before Layered runs and don't fire the event. Either
-			// way, Unmark on error prevents a leak.
+			// Contract: a non-nil error from the storage layer means no
+			// event was fired (verified for Layered: every error path
+			// returns before sendEvent; wrapper Databases short-circuit
+			// before Layered runs at all). The Mark would never be
+			// Consumed without this Unmark, so without it pending counts
+			// would accumulate on every storage failure.
 			if handlerTracker != nil {
 				handlerTracker.Unmark(itemKey)
 			}

--- a/handlers.go
+++ b/handlers.go
@@ -120,10 +120,13 @@ func Set(db storage.Database, path string, handlerTracker *HandlerWriteTracker, 
 		}
 		_, err = db.SetWithMeta(itemKey, decoded.Data, decoded.Created, decoded.Updated)
 		if err != nil {
-			// Drop the mark so it doesn't survive across requests — Layered.Set
-			// fires the event even on inner-layer rejection, so the callback
-			// will see and consume our mark; if it doesn't (wrapper rejection
-			// before Layered, like in failingItemStorage), Unmark prevents leak.
+			// Layered.Set returns errors only for input validation
+			// (ErrInvalidPath / ErrInvalidStorageData) — those paths suppress
+			// the event entirely, so our Mark would never be Consumed and
+			// would accumulate. Wrapper-level rejections (failingItemStorage
+			// in tests, custom Database wrappers in real use) also short-
+			// circuit before Layered runs and don't fire the event. Either
+			// way, Unmark on error prevents a leak.
 			if handlerTracker != nil {
 				handlerTracker.Unmark(itemKey)
 			}
@@ -148,10 +151,11 @@ func Set(db storage.Database, path string, handlerTracker *HandlerWriteTracker, 
 // Delete delete data on the pivot instance
 // handlerTracker / vvManager / postWrite mirror Set's parameters.
 //
-// This handler issues TWO storage writes (tombstone + Del), each of which
-// fires its own storage event. We Mark twice so the callback consumes
-// once per event and skips both, then Unmark on any failure path so
-// stale marks don't leak.
+// Only the itemKey storage event needs Mark/Consume dedup. The tombstone
+// Set fires an event for StoragePrefix+path (e.g. "pivot/things") which
+// doesn't match any configured Key.Path glob (e.g. "things/*"), so
+// makeStorageSync returns early at !found before reaching Consume —
+// Marking it would just accumulate forever.
 func Delete(db storage.Database, path string, handlerTracker *HandlerWriteTracker, vvManager *VVManager, postWrite PostWriteFunc) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		index := mux.Vars(r)["index"]
@@ -165,10 +169,7 @@ func Delete(db storage.Database, path string, handlerTracker *HandlerWriteTracke
 			itemKey = path + "/" + index
 		}
 		originatorPeer := r.Header.Get(OriginatorHeader)
-		// One mark per storage event we'll fire below.
-		tombstoneKey := StoragePrefix + path
 		if handlerTracker != nil {
-			handlerTracker.Mark(tombstoneKey)
 			handlerTracker.Mark(itemKey)
 		}
 		// Tombstone first, then Del. The reverse order leaves a window where
@@ -177,9 +178,8 @@ func Delete(db storage.Database, path string, handlerTracker *HandlerWriteTracke
 		// sync round re-fetch the item from a node that hasn't observed the
 		// delete and silently resurrect it. Writing the tombstone first means
 		// the worst case is an orphan tombstone, which sync resolves correctly.
-		if _, err := db.Set(tombstoneKey, json.RawMessage(time)); err != nil {
+		if _, err := db.Set(StoragePrefix+path, json.RawMessage(time)); err != nil {
 			if handlerTracker != nil {
-				handlerTracker.Unmark(tombstoneKey)
 				handlerTracker.Unmark(itemKey)
 			}
 			log.Printf("[pivot] Delete tombstone write failed for %q: %v", path, err)
@@ -187,8 +187,6 @@ func Delete(db storage.Database, path string, handlerTracker *HandlerWriteTracke
 			return
 		}
 		if err := db.Del(itemKey); err != nil {
-			// tombstone Mark was already consumed by the tombstone-Set event;
-			// only itemKey's mark is still pending.
 			if handlerTracker != nil {
 				handlerTracker.Unmark(itemKey)
 			}

--- a/handlers_internal_test.go
+++ b/handlers_internal_test.go
@@ -230,15 +230,64 @@ func TestSetVVIncrementsExactlyOnceUnderBurst(t *testing.T) {
 		require.Equal(t, 200, w.Code)
 	}
 
-	// Generous settle: every event must drain through the watch goroutine
-	// before we assert. If the callback double-bumped on any event, we'll
-	// see a counter > burst here.
-	time.Sleep(300 * time.Millisecond)
+	// Wait deterministically for the watch goroutine to drain every event;
+	// when tracker.Len() hits zero, every Mark has been Consumed.
+	require.Eventually(t, func() bool { return tracker.Len() == 0 }, 2*time.Second, 5*time.Millisecond,
+		"watch goroutine never drained all %d events", burst)
 
 	got := vvm.Get("things/abc")["leader"]
 	require.Equal(t, int64(burst), got,
 		"%d back-to-back HTTP Sets must bump leader counter exactly %d times; got %d means the per-key dedup collapsed under burst",
 		burst, burst, got)
+}
+
+// TestDeleteDoesNotLeakHandlerMarks pins the invariant that a handler-
+// driven Delete leaves the tracker empty after both storage events drain.
+// Pre-fix the handler Marked the tombstone key (StoragePrefix+path) too,
+// but the tombstone event doesn't match any configured Key.Path glob so
+// the storage callback returned at !found before reaching Consume — the
+// tombstone Mark accumulated forever.
+func TestDeleteDoesNotLeakHandlerMarks(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+
+	tracker := NewHandlerWriteTracker()
+	vvm := NewVVManager(db, "leader")
+	keys := []Key{{Path: "things/*", Database: db}}
+	instance := &Instance{VVManager: vvm}
+	storage.WatchWithCallback(db, makeStorageSync(StorageSyncConfig{
+		Keys:           keys,
+		GetNodes:       func() []string { return nil },
+		HandlerTracker: tracker,
+		Instance:       instance,
+	}))
+
+	// Seed a few items so each Delete actually has something to remove.
+	for _, idx := range []string{"a", "b", "c"} {
+		nowUnix := time.Now().UTC().UnixNano()
+		obj := meta.Object{Created: nowUnix, Updated: nowUnix, Index: idx, Path: "things/" + idx, Data: []byte(`{"v":1}`)}
+		body, err := json.Marshal(obj)
+		require.NoError(t, err)
+		_, err = db.SetWithMeta("things/"+idx, body, nowUnix, nowUnix)
+		require.NoError(t, err)
+	}
+	// Wait for the seeding events to drain so they don't influence the assertion.
+	require.Eventually(t, func() bool { return tracker.Len() == 0 }, 2*time.Second, 5*time.Millisecond)
+
+	handler := Delete(db, "things", tracker, vvm, nil)
+	for _, idx := range []string{"a", "b", "c"} {
+		ts := strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
+		req := httptest.NewRequest("DELETE", "/_pivot/pivot/things/"+idx+"/"+ts, nil)
+		req = mux.SetURLVars(req, map[string]string{"index": idx, "time": ts})
+		w := httptest.NewRecorder()
+		handler(w, req)
+		require.Equal(t, 200, w.Code)
+	}
+
+	require.Eventually(t, func() bool { return tracker.Len() == 0 }, 2*time.Second, 5*time.Millisecond,
+		"tracker leaked entries after Deletes drained: Len=%d", tracker.Len())
 }
 
 // TestSetPostWriteSeesBumpedVV pins the in-handler ordering: the post-write

--- a/handlers_internal_test.go
+++ b/handlers_internal_test.go
@@ -115,18 +115,18 @@ func TestSetVVIncrementsExactlyOnce(t *testing.T) {
 	require.NoError(t, db.Start(storage.Options{}))
 	defer db.Close()
 
-	originator := NewOriginatorTracker()
+	tracker := NewHandlerWriteTracker()
 	vvm := NewVVManager(db, "leader")
 	keys := []Key{{Path: "things/*", Database: db}}
 	instance := &Instance{VVManager: vvm}
 	storage.WatchWithCallback(db, makeStorageSync(StorageSyncConfig{
-		Keys:              keys,
-		GetNodes:          func() []string { return nil },
-		OriginatorTracker: originator,
-		Instance:          instance,
+		Keys:           keys,
+		GetNodes:       func() []string { return nil },
+		HandlerTracker: tracker,
+		Instance:       instance,
 	}))
 
-	handler := Set(db, "things", originator, vvm, nil)
+	handler := Set(db, "things", tracker, vvm, nil)
 
 	doSet := func(idx string) {
 		body := strings.NewReader(`{"created":0,"updated":0,"index":"` + idx + `","path":"things/` + idx + `","data":"e30="}`)
@@ -161,20 +161,20 @@ func TestSetVVIncrementsExactlyOnceNodeRole(t *testing.T) {
 	require.NoError(t, db.Start(storage.Options{}))
 	defer db.Close()
 
-	originator := NewOriginatorTracker()
+	tracker := NewHandlerWriteTracker()
 	vvm := NewVVManager(db, "127.0.0.1:9999") // node-style nodeID
 
 	keys := []Key{{Path: "things/*", Database: db}}
 	instance := &Instance{VVManager: vvm}
 	storage.WatchWithCallback(db, makeStorageSync(StorageSyncConfig{
-		Keys:              keys,
-		ConfigClusterURL:  "127.0.0.1:8000", // non-empty -> node mode
-		GetNodes:          func() []string { return nil },
-		OriginatorTracker: originator,
-		Instance:          instance,
+		Keys:             keys,
+		ConfigClusterURL: "127.0.0.1:8000", // non-empty -> node mode
+		GetNodes:         func() []string { return nil },
+		HandlerTracker:   tracker,
+		Instance:         instance,
 	}))
 
-	handler := Set(db, "things", originator, vvm, nil)
+	handler := Set(db, "things", tracker, vvm, nil)
 	body := strings.NewReader(`{"created":0,"updated":0,"index":"abc","path":"things/abc","data":"e30="}`)
 	req := httptest.NewRequest("POST", "/_pivot/pivot/things/abc", body)
 	req = mux.SetURLVars(req, map[string]string{"index": "abc"})
@@ -189,15 +189,68 @@ func TestSetVVIncrementsExactlyOnceNodeRole(t *testing.T) {
 		"node-role HTTP Set must bump local counter exactly once; got %d", got["127.0.0.1:9999"])
 }
 
-// TestSetPostWriteSeesBumpedVV pins the trigger-after-bump invariant. With
-// the post-write fanout running synchronously after the VV bump (not from
-// the async storage event callback), a peer woken by the trigger reads a
-// fresh VV every time. We assert this by hooking the post-write callback
-// and reading the VV inside it — the bump must already be visible.
+// TestSetVVIncrementsExactlyOnceUnderBurst pins the invariant that even
+// when N rapid handler-driven Sets to the same key fire before the watch
+// goroutine can drain any of them, the VV bumps exactly N times — not
+// N + (number-of-events-the-callback-double-bumps-for).
 //
-// Pre-fix this test would fail because the trigger fanout fired from the
-// storage callback running on the watch goroutine, which could race the
-// handler's own increment call.
+// Pre-fix the tracker stored a single per-key entry (last-writer-wins),
+// so K back-to-back handler Sets would collapse into one entry; the
+// callback would Take it on the first event and then find the tracker
+// empty for the remaining K-1 events and bump again. The fix uses a
+// per-key counter so each handler's Mark is matched by exactly one
+// Consume.
+func TestSetVVIncrementsExactlyOnceUnderBurst(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+
+	tracker := NewHandlerWriteTracker()
+	vvm := NewVVManager(db, "leader")
+	keys := []Key{{Path: "things/*", Database: db}}
+	instance := &Instance{VVManager: vvm}
+	storage.WatchWithCallback(db, makeStorageSync(StorageSyncConfig{
+		Keys:           keys,
+		GetNodes:       func() []string { return nil },
+		HandlerTracker: tracker,
+		Instance:       instance,
+	}))
+
+	handler := Set(db, "things", tracker, vvm, nil)
+
+	const burst = 10
+	for range burst {
+		body := strings.NewReader(`{"created":0,"updated":0,"index":"abc","path":"things/abc","data":"e30="}`)
+		req := httptest.NewRequest("POST", "/_pivot/pivot/things/abc", body)
+		req = mux.SetURLVars(req, map[string]string{"index": "abc"})
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler(w, req)
+		require.Equal(t, 200, w.Code)
+	}
+
+	// Generous settle: every event must drain through the watch goroutine
+	// before we assert. If the callback double-bumped on any event, we'll
+	// see a counter > burst here.
+	time.Sleep(300 * time.Millisecond)
+
+	got := vvm.Get("things/abc")["leader"]
+	require.Equal(t, int64(burst), got,
+		"%d back-to-back HTTP Sets must bump leader counter exactly %d times; got %d means the per-key dedup collapsed under burst",
+		burst, burst, got)
+}
+
+// TestSetPostWriteSeesBumpedVV pins the in-handler ordering: the post-write
+// hook runs after vvManager.increment, on the same goroutine. That's what
+// makes the trigger fanout fire AFTER the bump, so a peer woken by the
+// trigger reads a fresh VV.
+//
+// Note: this only pins the local sequence inside the handler. The actual
+// cross-process race (peer GET /activity racing our increment) is closed
+// by that local sequence — verifying it end-to-end would require two
+// httptest servers and intercepting the trigger HTTP call, which the
+// existing integration tests in cluster_test.go cover at a higher level.
 func TestSetPostWriteSeesBumpedVV(t *testing.T) {
 	monotonic.Init()
 	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
@@ -205,7 +258,7 @@ func TestSetPostWriteSeesBumpedVV(t *testing.T) {
 	defer db.Close()
 	storage.WatchWithCallback(db, func(storage.Event) {})
 
-	originator := NewOriginatorTracker()
+	tracker := NewHandlerWriteTracker()
 	vvm := NewVVManager(db, "leader")
 
 	var observedAt int64
@@ -213,7 +266,7 @@ func TestSetPostWriteSeesBumpedVV(t *testing.T) {
 		observedAt = vvm.Get(itemKey)["leader"]
 	}
 
-	handler := Set(db, "things", originator, vvm, postWrite)
+	handler := Set(db, "things", tracker, vvm, postWrite)
 
 	body := strings.NewReader(`{"created":0,"updated":0,"index":"abc","path":"things/abc","data":"e30="}`)
 	req := httptest.NewRequest("POST", "/_pivot/pivot/things/abc", body)
@@ -245,9 +298,9 @@ func TestSetVVDoesNotBumpOnStorageFailure(t *testing.T) {
 	}
 
 	vvm := NewVVManager(failing, "leader")
-	originator := NewOriginatorTracker()
+	tracker := NewHandlerWriteTracker()
 
-	handler := Set(failing, "things", originator, vvm, nil)
+	handler := Set(failing, "things", tracker, vvm, nil)
 
 	body := strings.NewReader(`{"created":0,"updated":0,"index":"abc","path":"things/abc","data":"e30="}`)
 	req := httptest.NewRequest("POST", "/_pivot/pivot/things/abc", body)
@@ -303,9 +356,9 @@ func TestDeleteVVDoesNotBumpOnStorageFailure(t *testing.T) {
 		err:          errors.New("simulated tombstone rejection"),
 	}
 	vvm := NewVVManager(failing, "leader")
-	originator := NewOriginatorTracker()
+	tracker := NewHandlerWriteTracker()
 
-	handler := Delete(failing, "things", originator, vvm, nil)
+	handler := Delete(failing, "things", tracker, vvm, nil)
 	deleteTS := strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
 	req := httptest.NewRequest("DELETE", "/_pivot/pivot/things/abc/"+deleteTS, nil)
 	req = mux.SetURLVars(req, map[string]string{"index": "abc", "time": deleteTS})

--- a/handlers_internal_test.go
+++ b/handlers_internal_test.go
@@ -74,7 +74,7 @@ func TestDeleteTombstoneAtomicity(t *testing.T) {
 		err:          errors.New("simulated tombstone write rejection"),
 	}
 
-	handler := Delete(failing, "things", nil, nil)
+	handler := Delete(failing, "things", nil, nil, nil)
 
 	deleteTS := strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
 	req := httptest.NewRequest("DELETE", "/_pivot/pivot/things/abc/"+deleteTS, nil)
@@ -126,7 +126,7 @@ func TestSetVVIncrementsExactlyOnce(t *testing.T) {
 		Instance:          instance,
 	}))
 
-	handler := Set(db, "things", originator, vvm)
+	handler := Set(db, "things", originator, vvm, nil)
 
 	doSet := func(idx string) {
 		body := strings.NewReader(`{"created":0,"updated":0,"index":"` + idx + `","path":"things/` + idx + `","data":"e30="}`)
@@ -174,7 +174,7 @@ func TestSetVVIncrementsExactlyOnceNodeRole(t *testing.T) {
 		Instance:          instance,
 	}))
 
-	handler := Set(db, "things", originator, vvm)
+	handler := Set(db, "things", originator, vvm, nil)
 	body := strings.NewReader(`{"created":0,"updated":0,"index":"abc","path":"things/abc","data":"e30="}`)
 	req := httptest.NewRequest("POST", "/_pivot/pivot/things/abc", body)
 	req = mux.SetURLVars(req, map[string]string{"index": "abc"})
@@ -187,6 +187,44 @@ func TestSetVVIncrementsExactlyOnceNodeRole(t *testing.T) {
 	got := vvm.Get("things/abc")
 	require.Equal(t, int64(1), got["127.0.0.1:9999"],
 		"node-role HTTP Set must bump local counter exactly once; got %d", got["127.0.0.1:9999"])
+}
+
+// TestSetPostWriteSeesBumpedVV pins the trigger-after-bump invariant. With
+// the post-write fanout running synchronously after the VV bump (not from
+// the async storage event callback), a peer woken by the trigger reads a
+// fresh VV every time. We assert this by hooking the post-write callback
+// and reading the VV inside it — the bump must already be visible.
+//
+// Pre-fix this test would fail because the trigger fanout fired from the
+// storage callback running on the watch goroutine, which could race the
+// handler's own increment call.
+func TestSetPostWriteSeesBumpedVV(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+	storage.WatchWithCallback(db, func(storage.Event) {})
+
+	originator := NewOriginatorTracker()
+	vvm := NewVVManager(db, "leader")
+
+	var observedAt int64
+	postWrite := func(itemKey, op, originatorPeer string) {
+		observedAt = vvm.Get(itemKey)["leader"]
+	}
+
+	handler := Set(db, "things", originator, vvm, postWrite)
+
+	body := strings.NewReader(`{"created":0,"updated":0,"index":"abc","path":"things/abc","data":"e30="}`)
+	req := httptest.NewRequest("POST", "/_pivot/pivot/things/abc", body)
+	req = mux.SetURLVars(req, map[string]string{"index": "abc"})
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler(w, req)
+	require.Equal(t, 200, w.Code)
+
+	require.Equal(t, int64(1), observedAt,
+		"post-write callback must see the bumped VV; got %d means the trigger fired before the bump", observedAt)
 }
 
 // TestSetVVDoesNotBumpOnStorageFailure pins the rollback invariant: if the
@@ -209,7 +247,7 @@ func TestSetVVDoesNotBumpOnStorageFailure(t *testing.T) {
 	vvm := NewVVManager(failing, "leader")
 	originator := NewOriginatorTracker()
 
-	handler := Set(failing, "things", originator, vvm)
+	handler := Set(failing, "things", originator, vvm, nil)
 
 	body := strings.NewReader(`{"created":0,"updated":0,"index":"abc","path":"things/abc","data":"e30="}`)
 	req := httptest.NewRequest("POST", "/_pivot/pivot/things/abc", body)
@@ -267,7 +305,7 @@ func TestDeleteVVDoesNotBumpOnStorageFailure(t *testing.T) {
 	vvm := NewVVManager(failing, "leader")
 	originator := NewOriginatorTracker()
 
-	handler := Delete(failing, "things", originator, vvm)
+	handler := Delete(failing, "things", originator, vvm, nil)
 	deleteTS := strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
 	req := httptest.NewRequest("DELETE", "/_pivot/pivot/things/abc/"+deleteTS, nil)
 	req = mux.SetURLVars(req, map[string]string{"index": "abc", "time": deleteTS})
@@ -300,7 +338,7 @@ func TestDeleteHappyPathStillCommitsBoth(t *testing.T) {
 	_, err = db.SetWithMeta(itemKey, body, nowUnix, nowUnix)
 	require.NoError(t, err)
 
-	handler := Delete(db, "things", nil, nil)
+	handler := Delete(db, "things", nil, nil, nil)
 	deleteTS := strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
 	req := httptest.NewRequest("DELETE", "/_pivot/pivot/things/abc/"+deleteTS, nil)
 	req = mux.SetURLVars(req, map[string]string{"index": "abc", "time": deleteTS})

--- a/handlers_internal_test.go
+++ b/handlers_internal_test.go
@@ -16,6 +16,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// pendingLen exposes the tracker's pending count for tests that need to
+// wait for the watch goroutine to drain. Lives in the test file so it
+// doesn't leak into the production API surface — production code has no
+// legitimate need to introspect the tracker.
+func (t *HandlerWriteTracker) pendingLen() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.pending)
+}
+
 // failingTombstoneStorage forces Set on the pivot tombstone prefix to fail.
 // VV writes (StoragePrefix+"vv/") are also under StoragePrefix, but the
 // Delete handler's tombstone target is "pivot/<basekey>" exactly, so the
@@ -231,8 +241,8 @@ func TestSetVVIncrementsExactlyOnceUnderBurst(t *testing.T) {
 	}
 
 	// Wait deterministically for the watch goroutine to drain every event;
-	// when tracker.Len() hits zero, every Mark has been Consumed.
-	require.Eventually(t, func() bool { return tracker.Len() == 0 }, 2*time.Second, 5*time.Millisecond,
+	// when tracker.pendingLen() hits zero, every Mark has been Consumed.
+	require.Eventually(t, func() bool { return tracker.pendingLen() == 0 }, 2*time.Second, 5*time.Millisecond,
 		"watch goroutine never drained all %d events", burst)
 
 	got := vvm.Get("things/abc")["leader"]
@@ -265,7 +275,10 @@ func TestDeleteDoesNotLeakHandlerMarks(t *testing.T) {
 	}))
 
 	// Seed a few items so each Delete actually has something to remove.
-	for _, idx := range []string{"a", "b", "c"} {
+	// Seeding goes through db.SetWithMeta directly (no Mark), so each event
+	// flows through the callback's empty-tracker branch and bumps VV.
+	indices := []string{"a", "b", "c"}
+	for _, idx := range indices {
 		nowUnix := time.Now().UTC().UnixNano()
 		obj := meta.Object{Created: nowUnix, Updated: nowUnix, Index: idx, Path: "things/" + idx, Data: []byte(`{"v":1}`)}
 		body, err := json.Marshal(obj)
@@ -273,8 +286,17 @@ func TestDeleteDoesNotLeakHandlerMarks(t *testing.T) {
 		_, err = db.SetWithMeta("things/"+idx, body, nowUnix, nowUnix)
 		require.NoError(t, err)
 	}
-	// Wait for the seeding events to drain so they don't influence the assertion.
-	require.Eventually(t, func() bool { return tracker.Len() == 0 }, 2*time.Second, 5*time.Millisecond)
+	// Wait until the seed VV bumps actually landed via the callback. Without
+	// this, a Delete fired before its seed event drained could observe an
+	// in-flight VV state and racy interactions could mask a regression.
+	require.Eventually(t, func() bool {
+		for _, idx := range indices {
+			if vvm.Get("things/" + idx)["leader"] != 1 {
+				return false
+			}
+		}
+		return true
+	}, 2*time.Second, 5*time.Millisecond, "seed VV bumps never landed")
 
 	handler := Delete(db, "things", tracker, vvm, nil)
 	for _, idx := range []string{"a", "b", "c"} {
@@ -286,8 +308,8 @@ func TestDeleteDoesNotLeakHandlerMarks(t *testing.T) {
 		require.Equal(t, 200, w.Code)
 	}
 
-	require.Eventually(t, func() bool { return tracker.Len() == 0 }, 2*time.Second, 5*time.Millisecond,
-		"tracker leaked entries after Deletes drained: Len=%d", tracker.Len())
+	require.Eventually(t, func() bool { return tracker.pendingLen() == 0 }, 2*time.Second, 5*time.Millisecond,
+		"tracker leaked entries after Deletes drained: Len=%d", tracker.pendingLen())
 }
 
 // TestSetPostWriteSeesBumpedVV pins the in-handler ordering: the post-write

--- a/handlers_internal_test.go
+++ b/handlers_internal_test.go
@@ -98,6 +98,188 @@ func TestDeleteTombstoneAtomicity(t *testing.T) {
 	require.NotEqual(t, 200, w.Code, "tombstone write failed but handler returned 200; client cannot retry an error it never saw")
 }
 
+// TestSetVVIncrementsExactlyOnce pins the invariant that a single HTTP Set
+// bumps the leader counter exactly once. Before the fix, the handler bumped
+// once before the storage write and the storage event callback bumped again
+// after, so each Set landed +2. Counters were therefore 2× what every other
+// peer thought they should be. Sync ordering still worked (strictly
+// monotonic) but the inflated values muddled divergence detection and any
+// future test that asserts an exact VV value.
+//
+// The fix moves the handler increment to *after* the storage write succeeds
+// and removes the callback's increment entirely; the handler is the sole
+// source of VV bumps for handler-driven writes.
+func TestSetVVIncrementsExactlyOnce(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+
+	originator := NewOriginatorTracker()
+	vvm := NewVVManager(db, "leader")
+	keys := []Key{{Path: "things/*", Database: db}}
+	instance := &Instance{VVManager: vvm}
+	storage.WatchWithCallback(db, makeStorageSync(StorageSyncConfig{
+		Keys:              keys,
+		GetNodes:          func() []string { return nil },
+		OriginatorTracker: originator,
+		Instance:          instance,
+	}))
+
+	handler := Set(db, "things", originator, vvm)
+
+	doSet := func(idx string) {
+		body := strings.NewReader(`{"created":0,"updated":0,"index":"` + idx + `","path":"things/` + idx + `","data":"e30="}`)
+		req := httptest.NewRequest("POST", "/_pivot/pivot/things/"+idx, body)
+		req = mux.SetURLVars(req, map[string]string{"index": idx})
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler(w, req)
+		require.Equal(t, 200, w.Code)
+	}
+
+	doSet("abc")
+	// Settle: callback runs in the watch goroutine, so we need to let any
+	// stray increment race past the handler's own Get before reading.
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, int64(1), vvm.Get("things/abc")["leader"], "first Set must bump leader counter to exactly 1")
+
+	doSet("abc")
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, int64(2), vvm.Get("things/abc")["leader"], "second Set must bump leader counter to exactly 2")
+}
+
+// TestSetVVIncrementsExactlyOnceNodeRole is the node-side mirror of
+// TestSetVVIncrementsExactlyOnce. Before the fix, node servers had no
+// originator tracker, so the dedup signal was missing and HTTP Sets to a
+// node still double-bumped via handler + callback. The fix creates an
+// originator tracker on every server (not just pivots) so the dedup works
+// for node-role keys too.
+func TestSetVVIncrementsExactlyOnceNodeRole(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+
+	originator := NewOriginatorTracker()
+	vvm := NewVVManager(db, "127.0.0.1:9999") // node-style nodeID
+
+	keys := []Key{{Path: "things/*", Database: db}}
+	instance := &Instance{VVManager: vvm}
+	storage.WatchWithCallback(db, makeStorageSync(StorageSyncConfig{
+		Keys:              keys,
+		ConfigClusterURL:  "127.0.0.1:8000", // non-empty -> node mode
+		GetNodes:          func() []string { return nil },
+		OriginatorTracker: originator,
+		Instance:          instance,
+	}))
+
+	handler := Set(db, "things", originator, vvm)
+	body := strings.NewReader(`{"created":0,"updated":0,"index":"abc","path":"things/abc","data":"e30="}`)
+	req := httptest.NewRequest("POST", "/_pivot/pivot/things/abc", body)
+	req = mux.SetURLVars(req, map[string]string{"index": "abc"})
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler(w, req)
+	require.Equal(t, 200, w.Code)
+	time.Sleep(100 * time.Millisecond)
+
+	got := vvm.Get("things/abc")
+	require.Equal(t, int64(1), got["127.0.0.1:9999"],
+		"node-role HTTP Set must bump local counter exactly once; got %d", got["127.0.0.1:9999"])
+}
+
+// TestSetVVDoesNotBumpOnStorageFailure pins the rollback invariant: if the
+// storage write fails, the VV must NOT be incremented. Otherwise peers
+// comparing VVs would see pivot ahead of its own data store and pull stale
+// values thinking they were current.
+func TestSetVVDoesNotBumpOnStorageFailure(t *testing.T) {
+	monotonic.Init()
+	real := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, real.Start(storage.Options{}))
+	defer real.Close()
+	storage.WatchWithCallback(real, func(storage.Event) {})
+
+	failing := &failingItemStorage{
+		Database:    real,
+		failItemKey: "things/abc",
+		err:         errors.New("simulated storage rejection"),
+	}
+
+	vvm := NewVVManager(failing, "leader")
+	originator := NewOriginatorTracker()
+
+	handler := Set(failing, "things", originator, vvm)
+
+	body := strings.NewReader(`{"created":0,"updated":0,"index":"abc","path":"things/abc","data":"e30="}`)
+	req := httptest.NewRequest("POST", "/_pivot/pivot/things/abc", body)
+	req = mux.SetURLVars(req, map[string]string{"index": "abc"})
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	require.Equal(t, 500, w.Code, "storage failure must surface as 500")
+	vv := vvm.Get("things/abc")
+	require.Equal(t, int64(0), vv["leader"],
+		"VV must not bump when the storage write failed; got %d means VV is now ahead of storage", vv["leader"])
+}
+
+// failingItemStorage forces SetWithMeta on a specific item to fail while
+// leaving every other Set/SetWithMeta path intact.
+type failingItemStorage struct {
+	storage.Database
+	failItemKey string
+	err         error
+}
+
+func (f *failingItemStorage) SetWithMeta(key string, data json.RawMessage, created, updated int64) (string, error) {
+	if key == f.failItemKey {
+		return key, f.err
+	}
+	return f.Database.SetWithMeta(key, data, created, updated)
+}
+
+// TestDeleteVVDoesNotBumpOnStorageFailure mirrors the Set rollback invariant
+// for the Delete handler: a tombstone-write failure must not leave the VV
+// incremented for a delete that never happened.
+func TestDeleteVVDoesNotBumpOnStorageFailure(t *testing.T) {
+	monotonic.Init()
+	real := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, real.Start(storage.Options{}))
+	defer real.Close()
+	storage.WatchWithCallback(real, func(storage.Event) {})
+
+	itemKey := "things/abc"
+	tombstoneKey := StoragePrefix + "things"
+
+	nowUnix := time.Now().UTC().UnixNano()
+	obj := meta.Object{Created: nowUnix, Updated: nowUnix, Index: "abc", Path: itemKey, Data: []byte(`{"v":1}`)}
+	body, err := json.Marshal(obj)
+	require.NoError(t, err)
+	_, err = real.SetWithMeta(itemKey, body, nowUnix, nowUnix)
+	require.NoError(t, err)
+
+	failing := &failingTombstoneStorage{
+		Database:     real,
+		tombstoneKey: tombstoneKey,
+		err:          errors.New("simulated tombstone rejection"),
+	}
+	vvm := NewVVManager(failing, "leader")
+	originator := NewOriginatorTracker()
+
+	handler := Delete(failing, "things", originator, vvm)
+	deleteTS := strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
+	req := httptest.NewRequest("DELETE", "/_pivot/pivot/things/abc/"+deleteTS, nil)
+	req = mux.SetURLVars(req, map[string]string{"index": "abc", "time": deleteTS})
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	require.Equal(t, 500, w.Code)
+	vv := vvm.Get(itemKey)
+	require.Equal(t, int64(0), vv["leader"],
+		"VV must not bump when the Delete tombstone write failed; got %d means VV is ahead of storage", vv["leader"])
+}
+
 // TestDeleteHappyPathStillCommitsBoth guards against an over-eager fix that
 // returns early in the success case. With healthy storage the handler must
 // still remove the item and write the tombstone.

--- a/pivot.go
+++ b/pivot.go
@@ -636,13 +636,27 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 	server.Router.HandleFunc(RoutePrefix+"/version", VersionHandler()).Methods("GET")
 	for _, k := range keys {
 		baseKey := baseKeyFromPath(k.Path)
+		// Build the per-key post-write closure once; the handler invokes it
+		// synchronously after the VV bump so peers woken by the trigger see
+		// the fresh VV.
+		effectiveURL := k.EffectiveClusterURL(pivotURL)
+		isPivotForKey := effectiveURL == ""
+		keyPath := k.Path
+		keyDB := k.Database
+		postWrite := func(itemKey, op, originatorPeer string) {
+			if isPivotForKey {
+				applyPivotFanout(instance, getNodesCached, nodeHealth, keyPath, originatorPeer)
+			} else {
+				applyNodePush(pool, keyDB, effectiveURL, op, itemKey)
+			}
+		}
 		server.Router.HandleFunc(RoutePrefix+"/activity/"+baseKey, Activity(k, vvManager)).Methods("GET")
 		if baseKey != k.Path {
-			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:[a-zA-Z\\*\\d\\/]+}", Set(k.Database, baseKey, originatorTracker, vvManager)).Methods("POST")
-			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:[a-zA-Z\\*\\d\\/]+}/{time:[a-zA-Z\\*\\d\\/]+}", Delete(k.Database, baseKey, originatorTracker, vvManager)).Methods("DELETE")
+			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:[a-zA-Z\\*\\d\\/]+}", Set(k.Database, baseKey, originatorTracker, vvManager, postWrite)).Methods("POST")
+			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:[a-zA-Z\\*\\d\\/]+}/{time:[a-zA-Z\\*\\d\\/]+}", Delete(k.Database, baseKey, originatorTracker, vvManager, postWrite)).Methods("DELETE")
 		} else {
-			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey, Set(k.Database, baseKey, originatorTracker, vvManager)).Methods("POST")
-			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{time:[a-zA-Z\\*\\d\\/]+}", Delete(k.Database, baseKey, originatorTracker, vvManager)).Methods("DELETE")
+			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey, Set(k.Database, baseKey, originatorTracker, vvManager, postWrite)).Methods("POST")
+			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{time:[a-zA-Z\\*\\d\\/]+}", Delete(k.Database, baseKey, originatorTracker, vvManager, postWrite)).Methods("DELETE")
 		}
 		// Expose GET routes for all synced keys
 		if baseKey != k.Path {

--- a/pivot.go
+++ b/pivot.go
@@ -572,13 +572,12 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 		}, nil
 	})
 
-	// Originator tracker is created on every server. On pivots it serves the
-	// trigger-fanout role (skip echoing back to the peer that just wrote);
-	// on both pivots and nodes it serves as the "handler is driving this VV
-	// bump" dedup signal so the storage event callback doesn't double-bump.
+	// Handler-write tracker is created on every server. The Set/Delete
+	// handlers Mark before each storage write so the async storage event
+	// callback knows to skip its own bump+fanout for handler-driven events.
 	// Create version vector manager for all servers (pivot uses LeaderID,
 	// nodes use their address).
-	originatorTracker := NewOriginatorTracker()
+	handlerTracker := NewHandlerWriteTracker()
 	var vvManager *VVManager
 	if pivotURL == "" {
 		vvManager = NewVVManager(server.Storage, LeaderID)
@@ -617,7 +616,7 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 		GetNodes:          getNodesCached,
 		Pool:              pool,
 		NodeHealth:        nodeHealth,
-		OriginatorTracker: originatorTracker,
+		HandlerTracker: handlerTracker,
 		Instance:          instance,
 	})
 
@@ -652,11 +651,11 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 		}
 		server.Router.HandleFunc(RoutePrefix+"/activity/"+baseKey, Activity(k, vvManager)).Methods("GET")
 		if baseKey != k.Path {
-			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:[a-zA-Z\\*\\d\\/]+}", Set(k.Database, baseKey, originatorTracker, vvManager, postWrite)).Methods("POST")
-			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:[a-zA-Z\\*\\d\\/]+}/{time:[a-zA-Z\\*\\d\\/]+}", Delete(k.Database, baseKey, originatorTracker, vvManager, postWrite)).Methods("DELETE")
+			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:[a-zA-Z\\*\\d\\/]+}", Set(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("POST")
+			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:[a-zA-Z\\*\\d\\/]+}/{time:[a-zA-Z\\*\\d\\/]+}", Delete(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("DELETE")
 		} else {
-			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey, Set(k.Database, baseKey, originatorTracker, vvManager, postWrite)).Methods("POST")
-			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{time:[a-zA-Z\\*\\d\\/]+}", Delete(k.Database, baseKey, originatorTracker, vvManager, postWrite)).Methods("DELETE")
+			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey, Set(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("POST")
+			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{time:[a-zA-Z\\*\\d\\/]+}", Delete(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("DELETE")
 		}
 		// Expose GET routes for all synced keys
 		if baseKey != k.Path {

--- a/pivot.go
+++ b/pivot.go
@@ -572,12 +572,15 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 		}, nil
 	})
 
-	// Create originator tracker for pivot servers to skip TriggerNodeSync back to originating node
-	// Create version vector manager for all servers (pivot uses LeaderID, nodes use their address)
-	var originatorTracker *OriginatorTracker
+	// Originator tracker is created on every server. On pivots it serves the
+	// trigger-fanout role (skip echoing back to the peer that just wrote);
+	// on both pivots and nodes it serves as the "handler is driving this VV
+	// bump" dedup signal so the storage event callback doesn't double-bump.
+	// Create version vector manager for all servers (pivot uses LeaderID,
+	// nodes use their address).
+	originatorTracker := NewOriginatorTracker()
 	var vvManager *VVManager
 	if pivotURL == "" {
-		originatorTracker = NewOriginatorTracker()
 		vvManager = NewVVManager(server.Storage, LeaderID)
 	} else {
 		// Node servers: VVManager will be initialized with node address once server starts

--- a/sync.go
+++ b/sync.go
@@ -861,15 +861,6 @@ func (t *HandlerWriteTracker) Consume(key string) bool {
 	return true
 }
 
-// Len returns the number of keys with non-zero pending counts. Intended
-// for tests that need to wait for the watch goroutine to drain all
-// outstanding events without sleeping.
-func (t *HandlerWriteTracker) Len() int {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return len(t.pending)
-}
-
 // applyPivotFanout triggers a sync on every healthy peer node except the
 // originating one. Shared between the Set/Delete handlers (called
 // synchronously after the local VV bump) and the storage event callback

--- a/sync.go
+++ b/sync.go
@@ -861,6 +861,15 @@ func (t *HandlerWriteTracker) Consume(key string) bool {
 	return true
 }
 
+// Len returns the number of keys with non-zero pending counts. Intended
+// for tests that need to wait for the watch goroutine to drain all
+// outstanding events without sleeping.
+func (t *HandlerWriteTracker) Len() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.pending)
+}
+
 // applyPivotFanout triggers a sync on every healthy peer node except the
 // originating one. Shared between the Set/Delete handlers (called
 // synchronously after the local VV bump) and the storage event callback
@@ -980,6 +989,15 @@ func makeStorageSync(cfg StorageSyncConfig) StorageSyncCallback {
 		// pre-bump VV would make it skip the pull. A miss means a direct
 		// (non-handler) storage write — the callback is then the only place
 		// that can bump and propagate.
+		//
+		// Caveat: a direct write that lands BETWEEN a handler's Mark and the
+		// watch goroutine processing the handler's event would Consume the
+		// handler's mark; the direct write would then get no bump/fanout
+		// here, and the handler's later event would find no mark and bump
+		// again. Closed-network deployment assumes a single writer per key
+		// path, so this race is unreachable in practice. If that assumption
+		// ever weakens, swap the per-key counter for an originator-tagged
+		// event id matched 1:1 to a handler write.
 		if cfg.HandlerTracker != nil && cfg.HandlerTracker.Consume(event.Key) {
 			return
 		}

--- a/sync.go
+++ b/sync.go
@@ -801,11 +801,28 @@ func (s *syncer) PulledSet(key string) bool {
 type StorageSyncCallback func(event storage.Event)
 
 // OriginatorTracker tracks which node originated a storage change.
-// This allows pivot to skip TriggerNodeSync back to the originating node.
+// Set serves two roles:
+//  1. Trigger fanout: when the originator is a peer node address, the
+//     storage callback skips re-triggering that peer (echo prevention).
+//  2. VV-bump dedup: presence of any entry signals "the handler will
+//     drive the VV bump after storage success" — the storage callback
+//     skips its own VV bump when an entry is present, so handler-driven
+//     writes bump exactly once. Direct (non-handler) storage writes
+//     leave the tracker empty and the callback bumps VV as before.
+//
+// Empty incoming originators (handler called with no OriginatorHeader)
+// are stored under a sentinel value so role 2 still fires; the sentinel
+// can't match any real node address, so role 1 acts as a no-op.
 type OriginatorTracker struct {
 	mu          sync.Mutex
 	originators map[string]string // key -> originator address
 }
+
+// originatorSelfMarker is the sentinel stored when a handler runs without
+// an OriginatorHeader. It must not collide with any real node address —
+// node addresses are host:port strings, which can't contain a literal
+// colon-prefixed sentinel like this one.
+const originatorSelfMarker = ":handler-self"
 
 // NewOriginatorTracker creates a new originator tracker
 func NewOriginatorTracker() *OriginatorTracker {
@@ -814,23 +831,37 @@ func NewOriginatorTracker() *OriginatorTracker {
 	}
 }
 
-// Set records the originator for a key (call before storage write)
+// Set records the originator for a key (call before storage write).
+// Empty originators are stored as a sentinel so the callback can still
+// see "this event was handler-driven" and skip its own VV bump.
 func (t *OriginatorTracker) Set(key, originator string) {
 	if originator == "" {
-		return
+		originator = originatorSelfMarker
 	}
 	t.mu.Lock()
 	t.originators[key] = originator
 	t.mu.Unlock()
 }
 
-// Get returns and clears the originator for a key (call in storage callback)
+// Get returns and clears the originator for a key (call in storage callback).
+// Returns "" if no entry was present.
 func (t *OriginatorTracker) Get(key string) string {
 	t.mu.Lock()
 	originator := t.originators[key]
 	delete(t.originators, key)
 	t.mu.Unlock()
 	return originator
+}
+
+// peerOriginator returns the originator only if it represents a real peer
+// (i.e. not the self-marker). Used by the callback's trigger fanout to
+// skip echoing back to the originating peer; the self-marker translates
+// to "no real peer" so fanout reaches every node.
+func peerOriginator(o string) string {
+	if o == originatorSelfMarker {
+		return ""
+	}
+	return o
 }
 
 // StorageSyncConfig holds configuration for storage sync callback creation.
@@ -902,19 +933,27 @@ func makeStorageSync(cfg StorageSyncConfig) StorageSyncCallback {
 		}
 
 		if isPivotForKey {
-			// This server IS pivot for this key - increment VV and notify all nodes asynchronously
-			if cfg.Instance != nil && cfg.Instance.VVManager != nil {
-				cfg.Instance.VVManager.increment(event.Key)
-			}
-			// Get and clear the originator for this key (set by handler before storage write)
+			// Get and clear the originator for this key (set by handler before storage write).
+			// A non-empty entry — including the self-marker — means a handler is
+			// driving this write and will bump VV after the storage write returns;
+			// we skip our own bump to avoid double-counting. An empty entry means
+			// some other code path wrote directly to storage, in which case we are
+			// the only chance to bump VV for that write.
 			var originator string
 			if cfg.OriginatorTracker != nil {
 				originator = cfg.OriginatorTracker.Get(event.Key)
 			}
+			if originator == "" {
+				if cfg.Instance != nil && cfg.Instance.VVManager != nil {
+					cfg.Instance.VVManager.increment(event.Key)
+				}
+			}
+			peer := peerOriginator(originator)
 			nodes := cfg.GetNodes()
 			for _, node := range nodes {
-				// Skip the originating node to prevent echo-back race condition
-				if node == originator {
+				// Skip the originating peer to prevent echo-back race condition.
+				// Self-marker collapses to "no peer", so fanout reaches all nodes.
+				if node == peer && peer != "" {
 					continue
 				}
 				// Skip incompatible nodes - don't sync to nodes with different protocol version
@@ -928,9 +967,17 @@ func makeStorageSync(cfg StorageSyncConfig) StorageSyncCallback {
 				cfg.Instance.triggers.Trigger(node, matchedKeyConfig.Path)
 			}
 		} else {
-			// This server is node for this key - increment local VV and sync to pivot
-			if cfg.Instance != nil && cfg.Instance.VVManager != nil {
-				cfg.Instance.VVManager.increment(event.Key)
+			// Node-side: same dedup story as the pivot branch — handler-driven
+			// writes leave a tracker entry and bump VV themselves; direct writes
+			// don't, so the callback bumps for them.
+			var originator string
+			if cfg.OriginatorTracker != nil {
+				originator = cfg.OriginatorTracker.Get(event.Key)
+			}
+			if originator == "" {
+				if cfg.Instance != nil && cfg.Instance.VVManager != nil {
+					cfg.Instance.VVManager.increment(event.Key)
+				}
 			}
 			if cfg.Pool != nil {
 				s := cfg.Pool.syncers[effectiveClusterURL]

--- a/sync.go
+++ b/sync.go
@@ -800,69 +800,65 @@ func (s *syncer) PulledSet(key string) bool {
 // StorageSyncCallback is the callback type for storage sync events
 type StorageSyncCallback func(event storage.Event)
 
-// OriginatorTracker tracks which node originated a storage change.
-// Set serves two roles:
-//  1. Trigger fanout: when the originator is a peer node address, the
-//     storage callback skips re-triggering that peer (echo prevention).
-//  2. VV-bump dedup: presence of any entry signals "the handler will
-//     drive the VV bump after storage success" — the storage callback
-//     skips its own VV bump when an entry is present, so handler-driven
-//     writes bump exactly once. Direct (non-handler) storage writes
-//     leave the tracker empty and the callback bumps VV as before.
+// HandlerWriteTracker counts in-flight handler-driven writes per key.
+// The Set/Delete handlers Mark before the storage write and the storage
+// event callback Consumes when the event lands; while the count for a
+// key is > 0, the callback knows a handler will own the post-write work
+// (VV bump + fanout/push) and skips its own. A counter — not a single
+// last-writer-wins entry — is required because two rapid handler writes
+// to the same key would otherwise have one tracker entry but produce
+// two storage events; the second event would find an empty tracker and
+// the callback would double-do the work.
 //
-// Empty incoming originators (handler called with no OriginatorHeader)
-// are stored under a sentinel value so role 2 still fires; the sentinel
-// can't match any real node address, so role 1 acts as a no-op.
-type OriginatorTracker struct {
-	mu          sync.Mutex
-	originators map[string]string // key -> originator address
+// Direct (non-handler) storage writes never call Mark, so Consume returns
+// false and the callback runs its full path — that's how the callback
+// remains the source of truth for direct writes.
+type HandlerWriteTracker struct {
+	mu      sync.Mutex
+	pending map[string]int
 }
 
-// originatorSelfMarker is the sentinel stored when a handler runs without
-// an OriginatorHeader. It must not collide with any real node address —
-// node addresses are host:port strings, which can't contain a literal
-// colon-prefixed sentinel like this one.
-const originatorSelfMarker = ":handler-self"
-
-// NewOriginatorTracker creates a new originator tracker
-func NewOriginatorTracker() *OriginatorTracker {
-	return &OriginatorTracker{
-		originators: make(map[string]string),
-	}
+// NewHandlerWriteTracker creates an empty tracker.
+func NewHandlerWriteTracker() *HandlerWriteTracker {
+	return &HandlerWriteTracker{pending: make(map[string]int)}
 }
 
-// Set records the originator for a key (call before storage write).
-// Empty originators are stored as a sentinel so the callback can still
-// see "this event was handler-driven" and skip its own VV bump.
-func (t *OriginatorTracker) Set(key, originator string) {
-	if originator == "" {
-		originator = originatorSelfMarker
-	}
+// Mark records that a handler is about to drive a write for the given key.
+// Must be called before the storage write so the dedup signal is in place
+// by the time the watch goroutine processes the event.
+func (t *HandlerWriteTracker) Mark(key string) {
 	t.mu.Lock()
-	t.originators[key] = originator
+	t.pending[key]++
 	t.mu.Unlock()
 }
 
-// Take returns and clears the originator for a key — call from the storage
-// callback (read-and-consume) or from a handler error path (drop a stale
-// entry). Returns "" if no entry was present.
-func (t *OriginatorTracker) Take(key string) string {
+// Unmark drops a previously-recorded mark — call from the handler's error
+// path when the storage write didn't fire an event.
+func (t *HandlerWriteTracker) Unmark(key string) {
 	t.mu.Lock()
-	originator := t.originators[key]
-	delete(t.originators, key)
+	if t.pending[key] > 0 {
+		t.pending[key]--
+		if t.pending[key] == 0 {
+			delete(t.pending, key)
+		}
+	}
 	t.mu.Unlock()
-	return originator
 }
 
-// peerOriginator returns the originator only if it represents a real peer
-// (i.e. not the self-marker). Used by the trigger fanout to skip echoing
-// back to the originating peer; the self-marker translates to "no real
-// peer" so fanout reaches every node.
-func peerOriginator(o string) string {
-	if o == originatorSelfMarker {
-		return ""
+// Consume returns true and decrements the pending count if a mark is
+// present for the key (i.e. this event is handler-driven). Returns false
+// otherwise (i.e. this event is from a direct storage write).
+func (t *HandlerWriteTracker) Consume(key string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.pending[key] == 0 {
+		return false
 	}
-	return o
+	t.pending[key]--
+	if t.pending[key] == 0 {
+		delete(t.pending, key)
+	}
+	return true
 }
 
 // applyPivotFanout triggers a sync on every healthy peer node except the
@@ -909,15 +905,15 @@ func applyNodePush(pool *syncerPool, db storage.Database, effectiveURL, op, item
 
 // StorageSyncConfig holds configuration for storage sync callback creation.
 type StorageSyncConfig struct {
-	Client            *http.Client
-	ConfigClusterURL  string
-	Keys              []Key
-	NodesKey          string
-	GetNodes          getNodes
-	Pool              *syncerPool
-	NodeHealth        *NodeHealth
-	OriginatorTracker *OriginatorTracker
-	Instance          *Instance
+	Client           *http.Client
+	ConfigClusterURL string
+	Keys             []Key
+	NodesKey         string
+	GetNodes         getNodes
+	Pool             *syncerPool
+	NodeHealth       *NodeHealth
+	HandlerTracker   *HandlerWriteTracker
+	Instance         *Instance
 }
 
 // makeStorageSync creates a callback that triggers synchronization on storage events.
@@ -976,19 +972,15 @@ func makeStorageSync(cfg StorageSyncConfig) StorageSyncCallback {
 		}
 
 		// Get and clear the originator for this key. A non-empty entry
-		// (including the self-marker) signals "a handler is driving this
-		// write and owns both the VV bump and the post-write fanout/push";
-		// we skip BOTH here so the handler can sequence them: bump first,
-		// then trigger peers. That ordering guarantee matters because a
-		// peer woken by the trigger immediately reads /activity to compare
-		// VVs, and seeing a pre-bump VV would make it skip the pull.
-		// An empty entry means a direct (non-handler) storage write — the
-		// callback is then the only place that can bump and propagate.
-		var originator string
-		if cfg.OriginatorTracker != nil {
-			originator = cfg.OriginatorTracker.Take(event.Key)
-		}
-		if originator != "" {
+		// Handler-driven writes Mark before db.Set, so a Consume hit means
+		// "a handler will own both the VV bump and the post-write fanout/push";
+		// skip BOTH here so the handler can sequence them: bump first, then
+		// trigger peers. That ordering guarantee matters because a peer woken
+		// by the trigger immediately reads /activity to compare VVs, and a
+		// pre-bump VV would make it skip the pull. A miss means a direct
+		// (non-handler) storage write — the callback is then the only place
+		// that can bump and propagate.
+		if cfg.HandlerTracker != nil && cfg.HandlerTracker.Consume(event.Key) {
 			return
 		}
 		if cfg.Instance != nil && cfg.Instance.VVManager != nil {

--- a/sync.go
+++ b/sync.go
@@ -843,9 +843,10 @@ func (t *OriginatorTracker) Set(key, originator string) {
 	t.mu.Unlock()
 }
 
-// Get returns and clears the originator for a key (call in storage callback).
-// Returns "" if no entry was present.
-func (t *OriginatorTracker) Get(key string) string {
+// Take returns and clears the originator for a key — call from the storage
+// callback (read-and-consume) or from a handler error path (drop a stale
+// entry). Returns "" if no entry was present.
+func (t *OriginatorTracker) Take(key string) string {
 	t.mu.Lock()
 	originator := t.originators[key]
 	delete(t.originators, key)
@@ -854,14 +855,56 @@ func (t *OriginatorTracker) Get(key string) string {
 }
 
 // peerOriginator returns the originator only if it represents a real peer
-// (i.e. not the self-marker). Used by the callback's trigger fanout to
-// skip echoing back to the originating peer; the self-marker translates
-// to "no real peer" so fanout reaches every node.
+// (i.e. not the self-marker). Used by the trigger fanout to skip echoing
+// back to the originating peer; the self-marker translates to "no real
+// peer" so fanout reaches every node.
 func peerOriginator(o string) string {
 	if o == originatorSelfMarker {
 		return ""
 	}
 	return o
+}
+
+// applyPivotFanout triggers a sync on every healthy peer node except the
+// originating one. Shared between the Set/Delete handlers (called
+// synchronously after the local VV bump) and the storage event callback
+// (called only for direct, non-handler writes).
+func applyPivotFanout(instance *Instance, getNodes getNodes, nodeHealth *NodeHealth, keyPath, originatorPeer string) {
+	if instance == nil || instance.triggers == nil || getNodes == nil {
+		return
+	}
+	for _, node := range getNodes() {
+		// Self-marker is collapsed by peerOriginator before this is called,
+		// so an originatorPeer of "" means "no peer to skip".
+		if node == originatorPeer && originatorPeer != "" {
+			continue
+		}
+		if nodeHealth != nil && !nodeHealth.IsCompatible(node) {
+			continue
+		}
+		instance.triggers.Trigger(node, keyPath)
+	}
+}
+
+// applyNodePush queues a Set or Delete to push to the pivot leader for the
+// node-role key. Shared between handler post-write and the storage event
+// callback's direct-write path.
+func applyNodePush(pool *syncerPool, db storage.Database, effectiveURL, op, itemKey string) {
+	if pool == nil {
+		return
+	}
+	s := pool.syncers[effectiveURL]
+	if s == nil {
+		return
+	}
+	if op == "del" {
+		s.QueueOrSendDelete(itemKey, time.Now().UnixNano())
+		return
+	}
+	obj, err := db.Get(itemKey)
+	if err == nil {
+		s.QueueOrSendSet(itemKey, obj)
+	}
 }
 
 // StorageSyncConfig holds configuration for storage sync callback creation.
@@ -932,66 +975,29 @@ func makeStorageSync(cfg StorageSyncConfig) StorageSyncCallback {
 			matchedDB.Del(StoragePrefix + matchedKey)
 		}
 
+		// Get and clear the originator for this key. A non-empty entry
+		// (including the self-marker) signals "a handler is driving this
+		// write and owns both the VV bump and the post-write fanout/push";
+		// we skip BOTH here so the handler can sequence them: bump first,
+		// then trigger peers. That ordering guarantee matters because a
+		// peer woken by the trigger immediately reads /activity to compare
+		// VVs, and seeing a pre-bump VV would make it skip the pull.
+		// An empty entry means a direct (non-handler) storage write — the
+		// callback is then the only place that can bump and propagate.
+		var originator string
+		if cfg.OriginatorTracker != nil {
+			originator = cfg.OriginatorTracker.Take(event.Key)
+		}
+		if originator != "" {
+			return
+		}
+		if cfg.Instance != nil && cfg.Instance.VVManager != nil {
+			cfg.Instance.VVManager.increment(event.Key)
+		}
 		if isPivotForKey {
-			// Get and clear the originator for this key (set by handler before storage write).
-			// A non-empty entry — including the self-marker — means a handler is
-			// driving this write and will bump VV after the storage write returns;
-			// we skip our own bump to avoid double-counting. An empty entry means
-			// some other code path wrote directly to storage, in which case we are
-			// the only chance to bump VV for that write.
-			var originator string
-			if cfg.OriginatorTracker != nil {
-				originator = cfg.OriginatorTracker.Get(event.Key)
-			}
-			if originator == "" {
-				if cfg.Instance != nil && cfg.Instance.VVManager != nil {
-					cfg.Instance.VVManager.increment(event.Key)
-				}
-			}
-			peer := peerOriginator(originator)
-			nodes := cfg.GetNodes()
-			for _, node := range nodes {
-				// Skip the originating peer to prevent echo-back race condition.
-				// Self-marker collapses to "no peer", so fanout reaches all nodes.
-				if node == peer && peer != "" {
-					continue
-				}
-				// Skip incompatible nodes - don't sync to nodes with different protocol version
-				if cfg.NodeHealth != nil && !cfg.NodeHealth.IsCompatible(node) {
-					continue
-				}
-				// The coalescer collapses bursts of triggers for the same node into a
-				// single in-flight HTTP call (drainer goroutine per node, 1-buffered
-				// notify, no timer). Setup always wires it on pivot servers, which
-				// is the only path that reaches this branch.
-				cfg.Instance.triggers.Trigger(node, matchedKeyConfig.Path)
-			}
+			applyPivotFanout(cfg.Instance, cfg.GetNodes, cfg.NodeHealth, matchedKeyConfig.Path, "")
 		} else {
-			// Node-side: same dedup story as the pivot branch — handler-driven
-			// writes leave a tracker entry and bump VV themselves; direct writes
-			// don't, so the callback bumps for them.
-			var originator string
-			if cfg.OriginatorTracker != nil {
-				originator = cfg.OriginatorTracker.Get(event.Key)
-			}
-			if originator == "" {
-				if cfg.Instance != nil && cfg.Instance.VVManager != nil {
-					cfg.Instance.VVManager.increment(event.Key)
-				}
-			}
-			if cfg.Pool != nil {
-				s := cfg.Pool.syncers[effectiveClusterURL]
-				if s != nil {
-					if event.Operation == "del" {
-						s.QueueOrSendDelete(event.Key, time.Now().UnixNano())
-					} else {
-						obj, err := matchedDB.Get(event.Key)
-						if err == nil {
-							s.QueueOrSendSet(event.Key, obj)
-						}
-					}
-				}
-			}
+			applyNodePush(cfg.Pool, matchedDB, effectiveClusterURL, event.Operation, event.Key)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Closes #40. Two related VV bugs in the `Set`/`Delete` HTTP handlers, plus a third found during review:

1. **Double-increment.** Every HTTP-driven write bumped VV twice — once in the handler before `db.Set`, once again in the storage event callback after. Counters were 2× their intended value.
2. **Bump before storage commit.** The handler's pre-storage bump was persisted via `saveToStorage` regardless of whether the data write actually committed, so a failed storage write left peers seeing pivot ahead of its own data.
3. **Trigger-after-bump ordering.** Once 1+2 were fixed by moving the bump after `db.Set`, the storage callback's trigger fanout still fired from the watch goroutine, before the handler reached its bump — a peer woken by the trigger could read `/activity` and see a pre-bump VV.

## Design after the fix
- New `HandlerWriteTracker` (per-key counter) — handlers `Mark` before each storage write, the storage event callback `Consume`s. Counter (not last-writer-wins string) is what makes bursts dedup correctly.
- Handlers run in this order: `Mark` → `db.Set/SetWithMeta` → `vvManager.increment` → `postWrite` (trigger fanout / leader push). Synchronous on the request goroutine — by the time `200` is written, the bump has landed and peers have been triggered with the fresh VV.
- Storage callback: if `Consume` hits, return early (handler owns this event). If it misses, bump VV and call the same fanout/push helpers — covers direct (non-handler) storage writes that the codebase relies on (e.g. cluster URL fingerprint, custom `AfterWrite` hooks).
- `PostWriteFunc` is constructed once per registered Key in `pivot.go` and threaded into the handler closures.

## Test plan
- [x] `TestSetVVIncrementsExactlyOnce` — pivot, exact `VV[leader]=1` after one Set, `=2` after two.
- [x] `TestSetVVIncrementsExactlyOnceNodeRole` — node mirror.
- [x] `TestSetVVIncrementsExactlyOnceUnderBurst` — 10 back-to-back Sets to the same key land exactly `VV=10`, not more (catches the burst-collapse race).
- [x] `TestSetVVDoesNotBumpOnStorageFailure` / `TestDeleteVVDoesNotBumpOnStorageFailure` — pin the rollback invariant.
- [x] `TestDeleteTombstoneAtomicity` — pin "item gone with no tombstone" is unreachable (this PR's closes-#38 follow-up was already merged; the test stays as a guard).
- [x] `TestDeleteHappyPathStillCommitsBoth` — ensure the success path still removes the item AND writes the tombstone.
- [x] `TestDeleteDoesNotLeakHandlerMarks` — pin no Mark accumulation per Delete (the tombstone event for `pivot/<base>` doesn't match any glob, so its Mark was leaking — fix removes that Mark).
- [x] `TestSetPostWriteSeesBumpedVV` — pin in-handler ordering: post-write hook sees the bumped VV.
- [x] Full pivot suite green at `go test -race -count=3`.

## Review history
Four independent review passes spotted, in order: the trigger-after-bump race (commit 2), the burst-collapse race (commit 3), the tombstone-Mark leak (commit 4), and three smaller comment/API tightening items (commit 5). All addressed. The remaining documented caveat is a direct-write-during-handler-window race — unreachable under the project's single-writer-per-key deployment assumption, and the callback comment flags it as the place to revisit if that assumption changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
