### PR TITLE
fix(sync): drive bidirectional sync by VV, not LastEntry alone

### DIFF
--- a/pivot.go
+++ b/pivot.go
@@ -501,9 +501,20 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 	getNodes := makeGetNodes(server, config.NodesKey, instance)
 	getNodesCached := makeGetNodesCached(instance)
 
+	// Construct VVManager first so the syncer pool can read local VVs
+	// when reconciling against a leader. nodeID stays empty on node
+	// servers until OnStart wires the actual address via SetNodeID.
+	var vvManager *VVManager
+	if pivotURL == "" {
+		vvManager = NewVVManager(server.Storage, LeaderID)
+	} else {
+		vvManager = NewVVManager(server.Storage, "")
+	}
+	instance.VVManager = vvManager
+
 	// Create syncer pool for keys that need outbound sync
 	// Keys with Local=true or where server IS pivot won't have syncers
-	pool := newSyncerPool(client, keys, pivotURL, config.SSL)
+	pool := newSyncerPool(client, keys, pivotURL, config.SSL, vvManager)
 
 	// Create node health tracker
 	// NodeHealth is needed if server is pivot for ANY key (pure pivot or mixed role)
@@ -575,18 +586,7 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 	// Handler-write tracker is created on every server. The Set/Delete
 	// handlers Mark before each storage write so the async storage event
 	// callback knows to skip its own bump+fanout for handler-driven events.
-	// Create version vector manager for all servers (pivot uses LeaderID,
-	// nodes use their address).
 	handlerTracker := NewHandlerWriteTracker()
-	var vvManager *VVManager
-	if pivotURL == "" {
-		vvManager = NewVVManager(server.Storage, LeaderID)
-	} else {
-		// Node servers: VVManager will be initialized with node address once server starts
-		// For now create with empty ID, will be set via SetNodeID later
-		vvManager = NewVVManager(server.Storage, "")
-	}
-	instance.VVManager = vvManager
 
 	// Per-node trigger coalescer — replaces the goroutine-per-event-per-node
 	// fan-out from the broadcast loop. Only pivot servers broadcast, so we
@@ -609,15 +609,15 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 	})
 
 	syncCallback := makeStorageSync(StorageSyncConfig{
-		Client:            client,
-		ConfigClusterURL:  pivotURL,
-		Keys:              keys,
-		NodesKey:          config.NodesKey,
-		GetNodes:          getNodesCached,
-		Pool:              pool,
-		NodeHealth:        nodeHealth,
-		HandlerTracker: handlerTracker,
-		Instance:          instance,
+		Client:           client,
+		ConfigClusterURL: pivotURL,
+		Keys:             keys,
+		NodesKey:         config.NodesKey,
+		GetNodes:         getNodesCached,
+		Pool:             pool,
+		NodeHealth:       nodeHealth,
+		HandlerTracker:   handlerTracker,
+		Instance:         instance,
 	})
 
 	// Set up OnStorageEvent for write/delete synchronization on server.Storage

--- a/sync.go
+++ b/sync.go
@@ -24,6 +24,13 @@ type SyncOptions struct {
 	OnSet          func(key string)
 	SkipSet        func(key string) bool
 	IsRecentDelete func(key string) bool
+	// VVManager exposes the local version vector to the bidirectional
+	// reconciler. When non-nil and both sides report a VV, direction is
+	// chosen by VV.Compare instead of LastEntry — the latter silently
+	// reports "nothing to synchronize" on timestamp collisions even when
+	// content actually diverges. Optional for backward compatibility:
+	// nil falls back to LastEntry-only logic.
+	VVManager *VVManager
 }
 
 // baseKeyFromPath strips all trailing glob segments (/*) from a path.
@@ -245,7 +252,6 @@ func syncToLeader(clientOpts ClientOpts, opts SyncOptions) error {
 }
 
 func synchronizeItemWithTracking(clientOpts ClientOpts, opts SyncOptions) error {
-	update := false
 	_key := baseKeyFromPath(opts.Key.Path)
 
 	activityLeader, err := checkLeaderActivity(clientOpts, _key)
@@ -257,7 +263,47 @@ func synchronizeItemWithTracking(clientOpts ClientOpts, opts SyncOptions) error 
 		return errors.New("failed to check activity for " + _key + " on local")
 	}
 
-	// sync local to leader (includes sending deletes for items deleted locally)
+	// checkActivity is a local read that doesn't carry the VV. Pull it
+	// from the manager directly so the comparison below has both sides.
+	if opts.VVManager != nil {
+		activityLocal.VV = opts.VVManager.Get(_key)
+	}
+
+	// Direction logic. When BOTH sides report a non-empty VV, use VV
+	// comparison — that's clock-independent and detects content
+	// divergence even when timestamps collide. Concurrent writes
+	// producing equal LastEntry but disjoint VV updates used to fall
+	// through the timestamp comparison and silently report "nothing to
+	// synchronize", leaving the cluster diverged until the next write
+	// bumped the timestamp past the collision.
+	//
+	// Fall back to LastEntry comparison when either side has no VV
+	// (older peers, or the very first sync before any VV bump).
+	useVV := len(activityLeader.VV) > 0 && len(activityLocal.VV) > 0
+	if useVV {
+		switch activityLocal.VV.Compare(activityLeader.VV) {
+		case VVEqual:
+			return errors.New("nothing to synchronize for " + opts.Key.Path)
+		case VVGreater:
+			opts.LastEntry = activityLeader.LastEntry
+			return syncToLeader(clientOpts, opts)
+		case VVLess:
+			opts.LastEntry = activityLeader.LastEntry
+			return syncLocalEntriesWithTracking(clientOpts, opts)
+		case VVConcurrent:
+			// Both sides have writes the other hasn't seen. Match the
+			// last-sync-wins convention from pullKeyWithCacheUpdate so
+			// the cluster converges on a single canonical state — local-
+			// only items are dropped this round but get re-pushed on the
+			// next sync after a write bumps local's VV further.
+			logConflict(_key, activityLocal.VV, activityLeader.VV, "last-sync-wins: pulling leader")
+			opts.LastEntry = activityLeader.LastEntry
+			return syncLocalEntriesWithTracking(clientOpts, opts)
+		}
+	}
+
+	// LastEntry fallback (backward compatibility with peers that don't expose VV).
+	update := false
 	if activityLocal.LastEntry > activityLeader.LastEntry {
 		opts.LastEntry = activityLeader.LastEntry
 		if err := syncToLeader(clientOpts, opts); err != nil {
@@ -266,7 +312,6 @@ func synchronizeItemWithTracking(clientOpts ClientOpts, opts SyncOptions) error 
 		update = true
 	}
 
-	// sync leader to local
 	if activityLocal.LastEntry < activityLeader.LastEntry {
 		opts.LastEntry = activityLeader.LastEntry
 		if err := syncLocalEntriesWithTracking(clientOpts, opts); err != nil {
@@ -364,15 +409,16 @@ type pendingOp struct {
 // It ensures only one sync runs at a time and tracks pulled keys.
 // Uses a per-key queue to ensure operations aren't lost during contention.
 type syncer struct {
-	mu       sync.Mutex
-	tracker  *pullTracker
-	client   *http.Client
-	pivot    string
-	keys     []Key
-	nodeAddr string // This node's address (for originator tracking)
-	ssl      bool   // Use HTTPS instead of HTTP
-	queueMu  sync.Mutex
-	queue    []pendingOp // Per-key operations queued during Pull
+	mu        sync.Mutex
+	tracker   *pullTracker
+	client    *http.Client
+	pivot     string
+	keys      []Key
+	nodeAddr  string     // This node's address (for originator tracking)
+	ssl       bool       // Use HTTPS instead of HTTP
+	vvManager *VVManager // Local VV manager — passed into SyncOptions so the bidirectional reconciler can compare VVs.
+	queueMu   sync.Mutex
+	queue     []pendingOp // Per-key operations queued during Pull
 
 	// Version vector cache: tracks last synced pivot VV per key.
 	// This is the primary sync indicator, independent of system clocks.
@@ -389,13 +435,14 @@ type syncer struct {
 	connected          map[string]bool  // baseKey -> true if we've received TriggerNodeSync for this key
 }
 
-func newSyncer(client *http.Client, pivot string, keys []Key, ssl bool) *syncer {
+func newSyncer(client *http.Client, pivot string, keys []Key, ssl bool, vvManager *VVManager) *syncer {
 	return &syncer{
 		tracker:            newPullTracker(),
 		client:             client,
 		pivot:              pivot,
 		keys:               keys,
 		ssl:                ssl,
+		vvManager:          vvManager,
 		queue:              make([]pendingOp, 0),
 		lastSyncedVV:       make(map[string]VersionVector),
 		lastSyncedActivity: make(map[string]int64),
@@ -421,7 +468,7 @@ type syncerPool struct {
 // newSyncerPool creates a syncer pool from keys grouped by their effective ClusterURL.
 // configClusterURL is used as fallback for keys without explicit ClusterURL.
 // ssl enables HTTPS for URL construction.
-func newSyncerPool(client *http.Client, keys []Key, configClusterURL string, ssl bool) *syncerPool {
+func newSyncerPool(client *http.Client, keys []Key, configClusterURL string, ssl bool, vvManager *VVManager) *syncerPool {
 	pool := &syncerPool{
 		syncers: make(map[string]*syncer),
 		keyMap:  make(map[string]string),
@@ -443,7 +490,7 @@ func newSyncerPool(client *http.Client, keys []Key, configClusterURL string, ssl
 
 	// Create a syncer for each unique pivot URL
 	for pivotURL, pivotKeys := range keysByPivot {
-		pool.syncers[pivotURL] = newSyncer(client, pivotURL, pivotKeys, ssl)
+		pool.syncers[pivotURL] = newSyncer(client, pivotURL, pivotKeys, ssl, vvManager)
 	}
 
 	return pool
@@ -781,6 +828,7 @@ func (s *syncer) Sync() error {
 		IsRecentDelete: s.tracker.pulledDelete,
 		OnDelete:       s.tracker.trackDelete,
 		OnSet:          s.tracker.trackSet,
+		VVManager:      s.vvManager,
 	}
 	err := synchronizeKeysWithTracking(s.ClientOpts(), opts, s.keys)
 	s.mu.Unlock()

--- a/sync_vv_divergence_test.go
+++ b/sync_vv_divergence_test.go
@@ -328,7 +328,7 @@ func TestSyncFallsBackToLastEntryWhenLeaderHasNoVV(t *testing.T) {
 
 	got, getErr := localDB.Get("things/x")
 	require.NoError(t, getErr, "leader's item must have been pulled locally")
-	require.Equal(t, "from-leader", string(got.Data[len("{\"v\":\""):len(got.Data)-2]),
+	require.JSONEq(t, `{"v":"from-leader"}`, string(got.Data),
 		"local copy must match leader's payload")
 }
 

--- a/sync_vv_divergence_test.go
+++ b/sync_vv_divergence_test.go
@@ -129,7 +129,7 @@ func TestSyncDetectsVVDivergenceOnEqualLastEntryPushCase(t *testing.T) {
 	vvm := NewVVManager(localDB, "127.0.0.1:9000")
 	vvm.set("things/*", VersionVector{"leader": 5, "127.0.0.1:9000": 3}) // normalizes to baseKey "things"; local strictly greater
 
-	leader, _ := stubLeader(t, "things", ActivityEntry{
+	leader, pushes := stubLeader(t, "things", ActivityEntry{
 		LastEntry: collidedTS,
 		VV:        VersionVector{"leader": 5},
 	}, []meta.Object{})
@@ -140,13 +140,66 @@ func TestSyncDetectsVVDivergenceOnEqualLastEntryPushCase(t *testing.T) {
 		Originator: "127.0.0.1:9000",
 		VVManager:  vvm,
 	})
-	// The fix's contract here: choose the push direction (call syncToLeader)
-	// instead of short-circuiting on equal LastEntry. Whether any item
-	// actually transfers is gated by syncToLeader's per-item timestamp
-	// guards (objLocal.Created > leaderActivity, etc.) — pre-existing and
-	// intentional. We just pin that the function no longer reports
-	// "nothing to synchronize".
 	require.NoError(t, err)
+
+	// Distinguish push from pull. With this scenario:
+	//   - Push (correct, VVGreater): syncToLeader runs against an empty leader
+	//     list. The local item's Created == leaderActivity, so syncToLeader's
+	//     per-item guard prevents the actual POST — pushes stays at 0. But
+	//     the local item is preserved.
+	//   - Pull (wrong direction): syncLocalEntriesWithTracking would see x in
+	//     local and not in leader, and DELETE x locally (negative-diff path).
+	//   - Pre-fix "nothing to synchronize": err != nil, already caught above.
+	// So the surviving local item is what pins push-direction.
+	_, getErr := localDB.Get("things/x")
+	require.NoError(t, getErr,
+		"VVGreater should pick push direction; the local-only item must NOT be deleted (which is what wrongly choosing pull would do)")
+	// pushes will be 0 here for the equal-timestamp edge case — syncToLeader's
+	// per-item Created>leaderActivity guard suppresses the POST. Pre-existing
+	// and orthogonal to this fix; documented in the issue's "practical impact
+	// bounded" note.
+	_ = pushes
+}
+
+// TestSyncPushDirectionPushesWhenItemTimestampsAllow exercises the same
+// VVGreater branch with a local item whose Updated strictly exceeds
+// leader's last activity, so syncToLeader's per-item guard lets the
+// POST through. Without this scenario, the push-case regression test
+// can't distinguish "push direction chosen but per-item guard fired"
+// from "the function silently no-op'd".
+func TestSyncPushDirectionPushesWhenItemTimestampsAllow(t *testing.T) {
+	monotonic.Init()
+	localDB := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, localDB.Start(storage.Options{}))
+	defer localDB.Close()
+	storage.WatchWithCallback(localDB, func(storage.Event) {})
+
+	leaderTS := int64(1_700_000_000_000_000_000)
+	localTS := leaderTS + 1_000_000 // strictly newer item
+
+	obj := meta.Object{Created: localTS, Updated: localTS, Index: "x", Path: "things/x", Data: []byte(`{"v":"local-newer"}`)}
+	body, err := json.Marshal(obj)
+	require.NoError(t, err)
+	_, err = localDB.SetWithMeta("things/x", body, localTS, localTS)
+	require.NoError(t, err)
+
+	vvm := NewVVManager(localDB, "127.0.0.1:9000")
+	vvm.set("things/*", VersionVector{"leader": 5, "127.0.0.1:9000": 3})
+
+	leader, pushes := stubLeader(t, "things", ActivityEntry{
+		LastEntry: leaderTS,
+		VV:        VersionVector{"leader": 5},
+	}, []meta.Object{})
+
+	clientOpts := ClientOpts{Client: http.DefaultClient, Leader: leader}
+	err = synchronizeItemWithTracking(clientOpts, SyncOptions{
+		Key:        Key{Path: "things/*", Database: localDB},
+		Originator: "127.0.0.1:9000",
+		VVManager:  vvm,
+	})
+	require.NoError(t, err)
+	require.Greater(t, pushes.Load(), int32(0),
+		"VVGreater with item timestamps that pass the per-item guard must POST to leader")
 }
 
 // TestSyncSkipsWhenVVsAreEqual: local and leader VVs are identical.
@@ -246,8 +299,11 @@ func TestSyncConcurrentVVsLogsAndPullsLeader(t *testing.T) {
 }
 
 // TestSyncFallsBackToLastEntryWhenLeaderHasNoVV: an old leader returns
-// activity without a VV. The bidirectional reconciler must fall back to
-// the existing LastEntry comparison so older peers continue to work.
+// activity without a VV. The reconciler must fall back to the existing
+// LastEntry comparison and pull the leader's item. Pinning that the
+// fallback path actually drives a pull (not just a no-op) — without an
+// item assertion the test would pass even if the fallback regressed
+// to "nothing to synchronize".
 func TestSyncFallsBackToLastEntryWhenLeaderHasNoVV(t *testing.T) {
 	monotonic.Init()
 	localDB := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
@@ -256,9 +312,10 @@ func TestSyncFallsBackToLastEntryWhenLeaderHasNoVV(t *testing.T) {
 	storage.WatchWithCallback(localDB, func(storage.Event) {})
 
 	leaderTS := int64(1_700_000_000_000_000_500)
+	leaderItem := meta.Object{Created: leaderTS, Updated: leaderTS, Index: "x", Path: "things/x", Data: []byte(`{"v":"from-leader"}`)}
 
 	// Leader reports newer LastEntry, NO VV (simulates an old peer).
-	leader, _ := stubLeader(t, "things", ActivityEntry{LastEntry: leaderTS}, []meta.Object{})
+	leader, _ := stubLeader(t, "things", ActivityEntry{LastEntry: leaderTS}, []meta.Object{leaderItem})
 
 	clientOpts := ClientOpts{Client: http.DefaultClient, Leader: leader}
 	vvm := NewVVManager(localDB, "127.0.0.1:9000")
@@ -267,13 +324,45 @@ func TestSyncFallsBackToLastEntryWhenLeaderHasNoVV(t *testing.T) {
 		Originator: "127.0.0.1:9000",
 		VVManager:  vvm,
 	})
-	// Local has nothing seeded so checkActivity reports LastEntry=0.
-	// Leader reports leaderTS > 0 → fallback path picks "pull leader to local".
-	// We only guard against the function silently reporting "nothing to
-	// synchronize" — any other outcome (nil error, or an error from the
-	// stub's degenerate GetList response) is acceptable.
-	if err != nil {
-		require.NotContains(t, err.Error(), "nothing to synchronize",
-			"LastEntry fallback should still drive a pull when leader is newer")
-	}
+	require.NoError(t, err, "fallback must drive a pull, not return 'nothing to synchronize'")
+
+	got, getErr := localDB.Get("things/x")
+	require.NoError(t, getErr, "leader's item must have been pulled locally")
+	require.Equal(t, "from-leader", string(got.Data[len("{\"v\":\""):len(got.Data)-2]),
+		"local copy must match leader's payload")
+}
+
+// TestSyncFallsBackToLastEntryWhenLocalHasNoVV: this server has just
+// started up and hasn't bumped its VV yet. Leader reports a non-empty
+// VV. The asymmetric case must still drive a pull via the LastEntry
+// fallback, not silently no-op. Worth pinning because a future change
+// could accidentally gate the VV path on either side's presence and
+// regress this code path.
+func TestSyncFallsBackToLastEntryWhenLocalHasNoVV(t *testing.T) {
+	monotonic.Init()
+	localDB := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, localDB.Start(storage.Options{}))
+	defer localDB.Close()
+	storage.WatchWithCallback(localDB, func(storage.Event) {})
+
+	leaderTS := int64(1_700_000_000_000_000_500)
+	leaderItem := meta.Object{Created: leaderTS, Updated: leaderTS, Index: "x", Path: "things/x", Data: []byte(`{"v":"from-leader"}`)}
+
+	// Leader has VV; local does not (no vvm.set calls).
+	leader, _ := stubLeader(t, "things", ActivityEntry{
+		LastEntry: leaderTS,
+		VV:        VersionVector{"leader": 5},
+	}, []meta.Object{leaderItem})
+
+	clientOpts := ClientOpts{Client: http.DefaultClient, Leader: leader}
+	vvm := NewVVManager(localDB, "127.0.0.1:9000")
+	err := synchronizeItemWithTracking(clientOpts, SyncOptions{
+		Key:        Key{Path: "things/*", Database: localDB},
+		Originator: "127.0.0.1:9000",
+		VVManager:  vvm,
+	})
+	require.NoError(t, err, "asymmetric VV (only leader) must fall back to LastEntry-driven pull")
+
+	_, getErr := localDB.Get("things/x")
+	require.NoError(t, getErr, "leader's item must have been pulled locally via LastEntry fallback")
 }

--- a/sync_vv_divergence_test.go
+++ b/sync_vv_divergence_test.go
@@ -1,0 +1,279 @@
+package pivot
+
+// Regression tests for the silent-divergence bug in
+// synchronizeItemWithTracking: when leader and local report equal
+// activity LastEntry but their version vectors disagree (concurrent
+// writes producing a timestamp collision), the function used to
+// short-circuit on the timestamp comparison and return "nothing to
+// synchronize" — leaving the cluster diverged until the next write
+// bumped LastEntry past the collision.
+//
+// The fix uses VV.Compare for direction whenever both sides expose a
+// VV, falling back to LastEntry-only logic when either side doesn't
+// (backward compatibility with old peers).
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/benitogf/ooo/meta"
+	"github.com/benitogf/ooo/monotonic"
+	"github.com/benitogf/ooo/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// stubLeader returns a leader HTTP server that reports a fixed activity
+// payload and serves an empty GetList. Push attempts (POST/DELETE) are
+// counted via the returned atomic so tests can assert direction.
+func stubLeader(t *testing.T, base string, activity ActivityEntry, list []meta.Object) (string, *atomic.Int32) {
+	t.Helper()
+	var pushes atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_pivot/activity/"+base, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(activity)
+	})
+	mux.HandleFunc("/_pivot/pivot/"+base+"/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(list)
+		default:
+			pushes.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	leader := srv.URL[len("http://"):]
+	return leader, &pushes
+}
+
+// TestSyncDetectsVVDivergenceOnEqualLastEntryPullCase: leader's VV
+// dominates local's VV (VVLess) at the same LastEntry. Pre-fix the
+// equal-timestamp short-circuit means no GetList is issued. Post-fix
+// the VV comparison picks the pull direction and triggers a GetList.
+func TestSyncDetectsVVDivergenceOnEqualLastEntryPullCase(t *testing.T) {
+	monotonic.Init()
+	localDB := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, localDB.Start(storage.Options{}))
+	defer localDB.Close()
+	storage.WatchWithCallback(localDB, func(storage.Event) {})
+
+	collidedTS := int64(1_700_000_000_000_000_000)
+	// Seed a single local item so checkActivity returns collidedTS.
+	obj := meta.Object{Created: collidedTS, Updated: collidedTS, Index: "x", Path: "things/x", Data: []byte(`{"v":"local"}`)}
+	body, err := json.Marshal(obj)
+	require.NoError(t, err)
+	_, err = localDB.SetWithMeta("things/x", body, collidedTS, collidedTS)
+	require.NoError(t, err)
+
+	// Local VV is strictly less than leader's: leader has 5 bumps from "leader",
+	// local has only seen 3.
+	vvm := NewVVManager(localDB, "127.0.0.1:9000")
+	vvm.set("things/*", VersionVector{"leader": 3}) // normalizes to baseKey "things"
+
+	// Leader reports the same LastEntry but a strictly greater VV.
+	var requestedGetList atomic.Bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_pivot/activity/things", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ActivityEntry{
+			LastEntry: collidedTS,
+			VV:        VersionVector{"leader": 5},
+		})
+	})
+	mux.HandleFunc("/_pivot/pivot/things/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			requestedGetList.Store(true)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]meta.Object{})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	leader := srv.URL[len("http://"):]
+
+	clientOpts := ClientOpts{Client: srv.Client(), Leader: leader}
+	err = synchronizeItemWithTracking(clientOpts, SyncOptions{
+		Key:        Key{Path: "things/*", Database: localDB},
+		Originator: "127.0.0.1:9000",
+		VVManager:  vvm,
+	})
+	require.NoError(t, err, "synchronizeItemWithTracking must not return 'nothing to synchronize' when VVs disagree at equal LastEntry")
+	require.True(t, requestedGetList.Load(),
+		"VV-driven direction should have triggered a GetList from leader; got no pull")
+}
+
+// TestSyncDetectsVVDivergenceOnEqualLastEntryPushCase: local's VV
+// dominates leader's VV (VVGreater) at the same LastEntry. Post-fix the
+// VV comparison picks the push direction and triggers a POST/DELETE to
+// leader.
+func TestSyncDetectsVVDivergenceOnEqualLastEntryPushCase(t *testing.T) {
+	monotonic.Init()
+	localDB := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, localDB.Start(storage.Options{}))
+	defer localDB.Close()
+	storage.WatchWithCallback(localDB, func(storage.Event) {})
+
+	collidedTS := int64(1_700_000_000_000_000_000)
+	obj := meta.Object{Created: collidedTS, Updated: collidedTS, Index: "x", Path: "things/x", Data: []byte(`{"v":"local"}`)}
+	body, err := json.Marshal(obj)
+	require.NoError(t, err)
+	_, err = localDB.SetWithMeta("things/x", body, collidedTS, collidedTS)
+	require.NoError(t, err)
+
+	vvm := NewVVManager(localDB, "127.0.0.1:9000")
+	vvm.set("things/*", VersionVector{"leader": 5, "127.0.0.1:9000": 3}) // normalizes to baseKey "things"; local strictly greater
+
+	leader, _ := stubLeader(t, "things", ActivityEntry{
+		LastEntry: collidedTS,
+		VV:        VersionVector{"leader": 5},
+	}, []meta.Object{})
+
+	clientOpts := ClientOpts{Client: http.DefaultClient, Leader: leader}
+	err = synchronizeItemWithTracking(clientOpts, SyncOptions{
+		Key:        Key{Path: "things/*", Database: localDB},
+		Originator: "127.0.0.1:9000",
+		VVManager:  vvm,
+	})
+	// The fix's contract here: choose the push direction (call syncToLeader)
+	// instead of short-circuiting on equal LastEntry. Whether any item
+	// actually transfers is gated by syncToLeader's per-item timestamp
+	// guards (objLocal.Created > leaderActivity, etc.) — pre-existing and
+	// intentional. We just pin that the function no longer reports
+	// "nothing to synchronize".
+	require.NoError(t, err)
+}
+
+// TestSyncSkipsWhenVVsAreEqual: local and leader VVs are identical.
+// Truly nothing to sync. Function returns the documented error and
+// makes no GetList / push.
+func TestSyncSkipsWhenVVsAreEqual(t *testing.T) {
+	monotonic.Init()
+	localDB := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, localDB.Start(storage.Options{}))
+	defer localDB.Close()
+	storage.WatchWithCallback(localDB, func(storage.Event) {})
+
+	collidedTS := int64(1_700_000_000_000_000_000)
+	vvm := NewVVManager(localDB, "127.0.0.1:9000")
+	vvm.set("things/*", VersionVector{"leader": 5})
+
+	var contacted atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_pivot/activity/things", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ActivityEntry{
+			LastEntry: collidedTS,
+			VV:        VersionVector{"leader": 5},
+		})
+	})
+	mux.HandleFunc("/_pivot/pivot/things/", func(w http.ResponseWriter, r *http.Request) {
+		contacted.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	leader := srv.URL[len("http://"):]
+
+	clientOpts := ClientOpts{Client: srv.Client(), Leader: leader}
+	err := synchronizeItemWithTracking(clientOpts, SyncOptions{
+		Key:        Key{Path: "things/*", Database: localDB},
+		Originator: "127.0.0.1:9000",
+		VVManager:  vvm,
+	})
+	require.Error(t, err, "equal VVs must return 'nothing to synchronize'")
+	require.Contains(t, err.Error(), "nothing to synchronize")
+	require.Zero(t, contacted.Load(), "no push or pull should have been issued when VVs match")
+}
+
+// TestSyncConcurrentVVsLogsAndPullsLeader: both sides have writes the
+// other hasn't seen (VVConcurrent). The convention — matching
+// pullKeyWithCacheUpdate — is last-sync-wins: log the conflict and pull
+// from leader. Local-only items are dropped this round; they get re-
+// pushed next sync after a write bumps local's VV further.
+func TestSyncConcurrentVVsLogsAndPullsLeader(t *testing.T) {
+	monotonic.Init()
+	localDB := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, localDB.Start(storage.Options{}))
+	defer localDB.Close()
+	storage.WatchWithCallback(localDB, func(storage.Event) {})
+
+	collidedTS := int64(1_700_000_000_000_000_000)
+	obj := meta.Object{Created: collidedTS, Updated: collidedTS, Index: "x", Path: "things/x", Data: []byte(`{"v":"local"}`)}
+	body, err := json.Marshal(obj)
+	require.NoError(t, err)
+	_, err = localDB.SetWithMeta("things/x", body, collidedTS, collidedTS)
+	require.NoError(t, err)
+
+	// Concurrent VVs: each side has counters the other doesn't dominate.
+	vvm := NewVVManager(localDB, "127.0.0.1:9000")
+	vvm.set("things/*", VersionVector{"127.0.0.1:9000": 5})
+
+	var requestedGetList atomic.Bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_pivot/activity/things", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ActivityEntry{
+			LastEntry: collidedTS,
+			VV:        VersionVector{"leader": 5}, // disjoint from local's counter
+		})
+	})
+	mux.HandleFunc("/_pivot/pivot/things/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			requestedGetList.Store(true)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]meta.Object{})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	leader := srv.URL[len("http://"):]
+
+	clientOpts := ClientOpts{Client: srv.Client(), Leader: leader}
+	err = synchronizeItemWithTracking(clientOpts, SyncOptions{
+		Key:        Key{Path: "things/*", Database: localDB},
+		Originator: "127.0.0.1:9000",
+		VVManager:  vvm,
+	})
+	require.NoError(t, err)
+	require.True(t, requestedGetList.Load(),
+		"VVConcurrent should have driven a pull from leader (last-sync-wins convention)")
+}
+
+// TestSyncFallsBackToLastEntryWhenLeaderHasNoVV: an old leader returns
+// activity without a VV. The bidirectional reconciler must fall back to
+// the existing LastEntry comparison so older peers continue to work.
+func TestSyncFallsBackToLastEntryWhenLeaderHasNoVV(t *testing.T) {
+	monotonic.Init()
+	localDB := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, localDB.Start(storage.Options{}))
+	defer localDB.Close()
+	storage.WatchWithCallback(localDB, func(storage.Event) {})
+
+	leaderTS := int64(1_700_000_000_000_000_500)
+
+	// Leader reports newer LastEntry, NO VV (simulates an old peer).
+	leader, _ := stubLeader(t, "things", ActivityEntry{LastEntry: leaderTS}, []meta.Object{})
+
+	clientOpts := ClientOpts{Client: http.DefaultClient, Leader: leader}
+	vvm := NewVVManager(localDB, "127.0.0.1:9000")
+	err := synchronizeItemWithTracking(clientOpts, SyncOptions{
+		Key:        Key{Path: "things/*", Database: localDB},
+		Originator: "127.0.0.1:9000",
+		VVManager:  vvm,
+	})
+	// Local has nothing seeded so checkActivity reports LastEntry=0.
+	// Leader reports leaderTS > 0 → fallback path picks "pull leader to local".
+	// We only guard against the function silently reporting "nothing to
+	// synchronize" — any other outcome (nil error, or an error from the
+	// stub's degenerate GetList response) is acceptable.
+	if err != nil {
+		require.NotContains(t, err.Error(), "nothing to synchronize",
+			"LastEntry fallback should still drive a pull when leader is newer")
+	}
+}

--- a/syncer_init_test.go
+++ b/syncer_init_test.go
@@ -77,7 +77,7 @@ func TestSyncerDefersSendUntilNodeAddrSet(t *testing.T) {
 	leader := newFakeLeader()
 	defer leader.close()
 
-	s := newSyncer(leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false)
+	s := newSyncer(leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false, nil)
 
 	now := monotonic.Now()
 	obj := meta.Object{
@@ -109,7 +109,7 @@ func TestSyncerDefersDeleteUntilNodeAddrSet(t *testing.T) {
 	leader := newFakeLeader()
 	defer leader.close()
 
-	s := newSyncer(leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false)
+	s := newSyncer(leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false, nil)
 
 	s.QueueOrSendDelete("things/abc", monotonic.Now())
 
@@ -129,7 +129,7 @@ func TestSyncerSendsImmediatelyAfterNodeAddrSet(t *testing.T) {
 	leader := newFakeLeader()
 	defer leader.close()
 
-	s := newSyncer(leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false)
+	s := newSyncer(leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false, nil)
 	const nodeAddr = "127.0.0.1:9003"
 	s.SetNodeAddr(nodeAddr)
 


### PR DESCRIPTION
## Summary
Closes #42.

`synchronizeItemWithTracking` decided sync direction by comparing `activityLocal.LastEntry` vs `activityLeader.LastEntry`. When the timestamps tied (concurrent writes producing a clock collision), neither branch fired and the function silently returned `"nothing to synchronize"`, leaving the cluster diverged until the next write bumped LastEntry past the collision.

## Design
When **both sides** report a non-empty VV, direction is chosen by `VersionVector.Compare`:

| Compare | Action |
| --- | --- |
| `VVEqual` | `"nothing to synchronize"` (no spurious work) |
| `VVGreater` | push (`syncToLeader`) |
| `VVLess` | pull (`syncLocalEntriesWithTracking`) |
| `VVConcurrent` | log + pull (matches existing `pullKeyWithCacheUpdate` last-sync-wins convention) |

When **either side** has a nil VV (older peer during a rolling upgrade, or this server hasn't bumped its VV yet), fall back to the existing LastEntry comparison so the cluster keeps working. Asymmetric VV presence (only one side reports a VV) also falls through to LastEntry — pinned by `TestSyncFallsBackToLastEntryWhenLocalHasNoVV`.

`SyncOptions.VVManager` is a new optional field threaded through `syncer` and `newSyncerPool`. The local `checkActivity` doesn't carry VV (only the HTTP Activity handler does), so the function reads local VV directly from the manager via `opts.VVManager.Get(_key)` after the local activity check.

## Behavior change worth flagging
Pre-fix, an `equal LastEntry + concurrent VVs` scenario produced silent divergence — both sides kept their unique items, and convergence relied on a subsequent write bumping LastEntry. Post-fix, that scenario picks **last-sync-wins** (matching `pullKeyWithCacheUpdate`'s existing convention): local-only items are dropped this round and re-pushed only if a later write bumps local's VV further. The convention is consistent with the project's broader sync semantics; the alternative (a true union/merge) would require a much larger change.

## Test plan
- [x] `TestSyncDetectsVVDivergenceOnEqualLastEntryPullCase` — equal LastEntry, VVLess → triggers a pull.
- [x] `TestSyncDetectsVVDivergenceOnEqualLastEntryPushCase` — equal LastEntry, VVGreater → push direction (asserted by local-only item surviving; pull would have deleted it via negative-diff).
- [x] `TestSyncPushDirectionPushesWhenItemTimestampsAllow` — VVGreater with item timestamps that pass `syncToLeader`'s per-item guard → actual POST lands on leader.
- [x] `TestSyncSkipsWhenVVsAreEqual` — equal VVs → `"nothing to synchronize"`, no leader-side work.
- [x] `TestSyncConcurrentVVsLogsAndPullsLeader` — VVConcurrent → log + pull (last-sync-wins).
- [x] `TestSyncFallsBackToLastEntryWhenLeaderHasNoVV` — old leader (no VV) → LastEntry-driven pull, leader item lands locally.
- [x] `TestSyncFallsBackToLastEntryWhenLocalHasNoVV` — asymmetric VV presence → fallback path still pulls.
- [x] Full pivot suite green at `go test -race -count=3`.

## Review history
Two independent review rounds. The first found that the push-case test only asserted `err == nil` (couldn't distinguish push from pull) and flagged toothless fallback assertions. The second found no blockers, plus a brittle JSON slice assertion (now `require.JSONEq`) and the VVConcurrent behavior note above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
