### PR TITLE
fix(vv): unify on path scope so /activity reflects writes (#45 part 1)

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -132,13 +132,17 @@ func Set(db storage.Database, path string, handlerTracker *HandlerWriteTracker, 
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		// VV bump after a successful storage write so the on-disk VV can
-		// never advance past data that wasn't written. The bump must
-		// complete BEFORE we trigger peers — otherwise a peer woken by the
-		// trigger could read /activity and see the pre-bump VV, conclude
-		// it's up to date, and skip the pull.
+		// VV bump after a successful storage write. Bump at PATH scope —
+		// the registered base path is what /activity exposes, what peers
+		// cache as lastSyncedVV, and what every other VV consumer reads.
+		// Bumping at item scope (the storage event's full key) would land
+		// in a separate, never-read VV entry; /activity would still
+		// expose an empty VV for glob paths and the whole VV machinery
+		// would silently degrade to LastEntry-only logic. The bump must
+		// complete BEFORE we trigger peers — otherwise a peer woken by
+		// the trigger could read /activity and see the pre-bump VV.
 		if vvManager != nil {
-			vvManager.increment(itemKey)
+			vvManager.increment(path)
 		}
 		if postWrite != nil {
 			postWrite(itemKey, "set", originatorPeer)
@@ -192,10 +196,11 @@ func Delete(db storage.Database, path string, handlerTracker *HandlerWriteTracke
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		// VV bump after both storage writes succeeded; bump must precede the
-		// post-write trigger so a peer woken by the trigger reads a fresh VV.
+		// VV bump at PATH scope (see the Set handler for the full rationale).
+		// Must precede the post-write trigger so a peer woken by the trigger
+		// reads a fresh VV.
 		if vvManager != nil {
-			vvManager.increment(itemKey)
+			vvManager.increment(path)
 		}
 		if postWrite != nil {
 			postWrite(itemKey, "del", originatorPeer)

--- a/handlers_internal_test.go
+++ b/handlers_internal_test.go
@@ -290,7 +290,6 @@ func TestDeleteDoesNotLeakHandlerMarks(t *testing.T) {
 	// seed bumps path-scope "things" once (the callback increments at the
 	// matched key's base, not the storage event's full key), so after three
 	// seeds the path-scope leader counter must be 3.
-	_ = indices // kept for clarity in the loop above
 	require.Eventually(t, func() bool {
 		return vvm.Get("things")["leader"] >= 3
 	}, 2*time.Second, 5*time.Millisecond, "seed VV bumps never landed")
@@ -436,7 +435,7 @@ func TestDeleteVVDoesNotBumpOnStorageFailure(t *testing.T) {
 	handler(w, req)
 
 	require.Equal(t, 500, w.Code)
-	vv := vvm.Get(itemKey)
+	vv := vvm.Get("things")
 	require.Equal(t, int64(0), vv["leader"],
 		"VV must not bump when the Delete tombstone write failed; got %d means VV is ahead of storage", vv["leader"])
 }

--- a/handlers_internal_test.go
+++ b/handlers_internal_test.go
@@ -152,11 +152,11 @@ func TestSetVVIncrementsExactlyOnce(t *testing.T) {
 	// Settle: callback runs in the watch goroutine, so we need to let any
 	// stray increment race past the handler's own Get before reading.
 	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, int64(1), vvm.Get("things/abc")["leader"], "first Set must bump leader counter to exactly 1")
+	require.Equal(t, int64(1), vvm.Get("things")["leader"], "first Set must bump leader counter to exactly 1")
 
 	doSet("abc")
 	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, int64(2), vvm.Get("things/abc")["leader"], "second Set must bump leader counter to exactly 2")
+	require.Equal(t, int64(2), vvm.Get("things")["leader"], "second Set must bump leader counter to exactly 2")
 }
 
 // TestSetVVIncrementsExactlyOnceNodeRole is the node-side mirror of
@@ -194,7 +194,7 @@ func TestSetVVIncrementsExactlyOnceNodeRole(t *testing.T) {
 	require.Equal(t, 200, w.Code)
 	time.Sleep(100 * time.Millisecond)
 
-	got := vvm.Get("things/abc")
+	got := vvm.Get("things")
 	require.Equal(t, int64(1), got["127.0.0.1:9999"],
 		"node-role HTTP Set must bump local counter exactly once; got %d", got["127.0.0.1:9999"])
 }
@@ -245,7 +245,7 @@ func TestSetVVIncrementsExactlyOnceUnderBurst(t *testing.T) {
 	require.Eventually(t, func() bool { return tracker.pendingLen() == 0 }, 2*time.Second, 5*time.Millisecond,
 		"watch goroutine never drained all %d events", burst)
 
-	got := vvm.Get("things/abc")["leader"]
+	got := vvm.Get("things")["leader"]
 	require.Equal(t, int64(burst), got,
 		"%d back-to-back HTTP Sets must bump leader counter exactly %d times; got %d means the per-key dedup collapsed under burst",
 		burst, burst, got)
@@ -286,16 +286,13 @@ func TestDeleteDoesNotLeakHandlerMarks(t *testing.T) {
 		_, err = db.SetWithMeta("things/"+idx, body, nowUnix, nowUnix)
 		require.NoError(t, err)
 	}
-	// Wait until the seed VV bumps actually landed via the callback. Without
-	// this, a Delete fired before its seed event drained could observe an
-	// in-flight VV state and racy interactions could mask a regression.
+	// Wait until the seed VV bumps actually landed via the callback. Each
+	// seed bumps path-scope "things" once (the callback increments at the
+	// matched key's base, not the storage event's full key), so after three
+	// seeds the path-scope leader counter must be 3.
+	_ = indices // kept for clarity in the loop above
 	require.Eventually(t, func() bool {
-		for _, idx := range indices {
-			if vvm.Get("things/" + idx)["leader"] != 1 {
-				return false
-			}
-		}
-		return true
+		return vvm.Get("things")["leader"] >= 3
 	}, 2*time.Second, 5*time.Millisecond, "seed VV bumps never landed")
 
 	handler := Delete(db, "things", tracker, vvm, nil)
@@ -334,7 +331,9 @@ func TestSetPostWriteSeesBumpedVV(t *testing.T) {
 
 	var observedAt int64
 	postWrite := func(itemKey, op, originatorPeer string) {
-		observedAt = vvm.Get(itemKey)["leader"]
+		// VV is bumped at path scope ("things"), not itemKey scope —
+		// see the increment in the Set handler.
+		observedAt = vvm.Get("things")["leader"]
 	}
 
 	handler := Set(db, "things", tracker, vvm, postWrite)
@@ -381,7 +380,7 @@ func TestSetVVDoesNotBumpOnStorageFailure(t *testing.T) {
 	handler(w, req)
 
 	require.Equal(t, 500, w.Code, "storage failure must surface as 500")
-	vv := vvm.Get("things/abc")
+	vv := vvm.Get("things")
 	require.Equal(t, int64(0), vv["leader"],
 		"VV must not bump when the storage write failed; got %d means VV is now ahead of storage", vv["leader"])
 }

--- a/sync.go
+++ b/sync.go
@@ -633,11 +633,13 @@ func (s *syncer) pullKeyWithCacheUpdate(keys []Key) error {
 		// Always read local activity. The LastEntry path is the
 		// authoritative signal for "pivot has data my LastEntry doesn't
 		// reflect" because pivot's LastEntry advances synchronously with
-		// the storage write — the VV bump runs in the async storage
-		// event callback and can briefly lag. Without this fallback, a
-		// read that lands in the lag window sees activityPivot.VV ==
-		// lastSyncedVV (no advance yet) and skips a needed pull, leaving
-		// stale data locally until the next storage event drains.
+		// the storage write. The VV bump for DIRECT writes (writes that
+		// don't go through pivot's Set/Delete handlers — e.g. ooo's
+		// standard route, custom AfterWrite hooks, internal mutations)
+		// runs in the async storage event callback and can briefly lag
+		// the storage write. Handler-driven writes are synchronous and
+		// don't have this gap, but we can't tell the two paths apart
+		// from here — so always check LastEntry as a fallback signal.
 		activityLocal, actErr := checkActivity(_key)
 
 		if len(activityPivot.VV) > 0 && hasLocalVV {

--- a/sync.go
+++ b/sync.go
@@ -630,27 +630,31 @@ func (s *syncer) pullKeyWithCacheUpdate(keys []Key) error {
 		localVV, hasLocalVV := s.lastSyncedVV[baseKey]
 		s.vvMu.RUnlock()
 
+		// Always read local activity. The LastEntry path is the
+		// authoritative signal for "pivot has data my LastEntry doesn't
+		// reflect" because pivot's LastEntry advances synchronously with
+		// the storage write — the VV bump runs in the async storage
+		// event callback and can briefly lag. Without this fallback, a
+		// read that lands in the lag window sees activityPivot.VV ==
+		// lastSyncedVV (no advance yet) and skips a needed pull, leaving
+		// stale data locally until the next storage event drains.
+		activityLocal, actErr := checkActivity(_key)
+
 		if len(activityPivot.VV) > 0 && hasLocalVV {
 			// Version vector comparison (preferred, clock-independent)
-			// Compare pivot's VV with our last synced VV
 			switch localVV.Compare(activityPivot.VV) {
 			case VVLess:
-				// Local is behind pivot - need to sync
 				needSync = true
 			case VVConcurrent:
-				// Conflict detected - log and sync (last-sync-wins)
 				logConflict(baseKey, localVV, activityPivot.VV, "last-sync-wins: accepting pivot data")
 				needSync = true
 			}
-			// VVEqual or VVGreater means no sync needed
-		} else {
-			// Fallback: timestamp-based comparison
-			// Used for backward compatibility and first sync (before we have local VV)
-			activityLocal, err := checkActivity(_key)
-			if err != nil {
-				continue
-			}
-			needSync = activityPivot.LastEntry > activityLocal.LastEntry
+		}
+
+		// LastEntry secondary signal — independent of the VV branch above.
+		// Catches the VV-lag case described at the top of this loop.
+		if actErr == nil && activityPivot.LastEntry > activityLocal.LastEntry {
+			needSync = true
 		}
 
 		// Update caches with pivot's current values
@@ -1041,7 +1045,11 @@ func makeStorageSync(cfg StorageSyncConfig) StorageSyncCallback {
 			return
 		}
 		if cfg.Instance != nil && cfg.Instance.VVManager != nil {
-			cfg.Instance.VVManager.increment(event.Key)
+			// Increment at PATH scope — matchedKey is already
+			// baseKeyFromPath(matchedKeyConfig.Path), the same scope
+			// /activity exposes. Bumping at event.Key (item scope)
+			// would land in a separate, never-read VV entry.
+			cfg.Instance.VVManager.increment(matchedKey)
 		}
 		if isPivotForKey {
 			applyPivotFanout(cfg.Instance, cfg.GetNodes, cfg.NodeHealth, matchedKeyConfig.Path, "")

--- a/vv_path_scope_test.go
+++ b/vv_path_scope_test.go
@@ -1,0 +1,139 @@
+package pivot
+
+// Regression test for the VV-scope mismatch in production. Pre-fix:
+// handlers and the storage callback called increment with the storage
+// event's full key (e.g. "things/x"), which baseKeyFromPath leaves at
+// item-scope. The /activity endpoint exposed VV via Get(_key.Path),
+// which normalized "things/*" to path-scope ("things"). Two different
+// scopes → /activity always returned an empty VV for glob keys, and
+// every VV-aware sync feature silently fell back to LastEntry-only
+// logic.
+//
+// The fix unifies on path-scope: increment normalizes its argument
+// down to the base path, so a write to "things/x" bumps the same VV
+// the /activity handler reads. The two halves of the VV system now
+// share state.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/benitogf/ooo/monotonic"
+	"github.com/benitogf/ooo/storage"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+// TestActivityExposesVVAfterGlobWrite is the headline regression
+// test: a write under a glob path must show up in the VV that
+// /activity exposes for that path. Pre-fix this was always empty.
+func TestActivityExposesVVAfterGlobWrite(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+	storage.WatchWithCallback(db, func(storage.Event) {})
+
+	vvm := NewVVManager(db, "leader")
+	tracker := NewHandlerWriteTracker()
+
+	// Wire a Set handler the way a glob-path key registers it: path=
+	// "things" (the registered base, with the /* stripped before
+	// mounting) and items go under "things/<index>".
+	setHandler := Set(db, "things", tracker, vvm, nil)
+
+	// Drive a write under the glob.
+	body := strings.NewReader(`{"created":0,"updated":0,"index":"x","path":"things/x","data":"e30="}`)
+	req := httptest.NewRequest("POST", "/_pivot/pivot/things/x", body)
+	req = mux.SetURLVars(req, map[string]string{"index": "x"})
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	setHandler(w, req)
+	require.Equal(t, 200, w.Code)
+
+	// Stand up the Activity handler the way pivot.go registers it:
+	// the Key.Path is the glob, "things/*". Activity normalizes that
+	// to "things" and reads the VV under that base key.
+	activityHandler := Activity(Key{Path: "things/*", Database: db}, vvm)
+	areq := httptest.NewRequest("GET", "/_pivot/activity/things", nil)
+	aw := httptest.NewRecorder()
+	activityHandler(aw, areq)
+	require.Equal(t, 200, aw.Code)
+
+	// The body is JSON-decoded ActivityEntry; check its VV directly via
+	// the manager (same path) — equivalent and avoids a second decode
+	// round-trip in this test.
+	exposedVV := vvm.Get("things/*")
+	require.NotEmpty(t, exposedVV,
+		"after a glob-path write, /activity must expose a non-empty VV; got %v", exposedVV)
+	require.Equal(t, int64(1), exposedVV["leader"],
+		"the leader counter must reflect the handler's increment for the path")
+}
+
+// TestCallbackIncrementsAtPathScope is the storage-callback mirror.
+// Direct (non-handler) writes flow through the storage event callback,
+// which also has to bump VV at path-scope so /activity stays consistent.
+func TestCallbackIncrementsAtPathScope(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+
+	vvm := NewVVManager(db, "leader")
+	keys := []Key{{Path: "things/*", Database: db}}
+	instance := &Instance{VVManager: vvm}
+	storage.WatchWithCallback(db, makeStorageSync(StorageSyncConfig{
+		Keys:     keys,
+		GetNodes: func() []string { return nil },
+		Instance: instance,
+	}))
+
+	// Direct storage write — bypasses the Set handler, so the storage
+	// callback is the one bumping VV.
+	_, err := db.SetWithMeta("things/x", []byte(`{"v":"v1"}`), 1, 1)
+	require.NoError(t, err)
+
+	// Settle for the watch goroutine. The callback is the only thing
+	// touching VV here, and increments synchronously inside the
+	// goroutine — a small wait is enough.
+	require.Eventually(t, func() bool {
+		return vvm.Get("things/*")["leader"] >= 1
+	}, 1*1_000_000_000, 5*1_000_000,
+		"storage callback must increment path-scope VV on direct writes")
+}
+
+// TestHandlerIncrementMatchesActivityScope pins the symmetry: every
+// handler-driven write produces a VV that Activity exposes 1:1. If a
+// future change re-introduces an item-scope increment, this test
+// regresses immediately.
+func TestHandlerIncrementMatchesActivityScope(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+	storage.WatchWithCallback(db, func(storage.Event) {})
+
+	vvm := NewVVManager(db, "leader")
+	setHandler := Set(db, "things", NewHandlerWriteTracker(), vvm, nil)
+
+	for i, idx := range []string{"a", "b", "c"} {
+		body := strings.NewReader(`{"created":0,"updated":0,"index":"` + idx + `","path":"things/` + idx + `","data":"e30="}`)
+		req := httptest.NewRequest("POST", "/_pivot/pivot/things/"+idx, body)
+		req = mux.SetURLVars(req, map[string]string{"index": idx})
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		setHandler(w, req)
+		require.Equal(t, 200, w.Code, "write %d failed", i)
+	}
+
+	// Three writes under the same registered glob path → one VV with
+	// leader counter at 3. Pre-fix each write bumped a separate item-
+	// scope VV (things/a, things/b, things/c) — none of which /activity
+	// would have read.
+	exposedVV := vvm.Get("things/*")
+	require.Equal(t, int64(3), exposedVV["leader"],
+		"three writes under things/* must increment the path-scope VV by 3; got %v", exposedVV)
+	_ = http.StatusOK // keep import
+}

--- a/vv_path_scope_test.go
+++ b/vv_path_scope_test.go
@@ -15,10 +15,10 @@ package pivot
 // share state.
 
 import (
-	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/benitogf/ooo/monotonic"
 	"github.com/benitogf/ooo/storage"
@@ -29,15 +29,28 @@ import (
 // TestActivityExposesVVAfterGlobWrite is the headline regression
 // test: a write under a glob path must show up in the VV that
 // /activity exposes for that path. Pre-fix this was always empty.
+//
+// The full production callback is wired here (not a no-op) so the
+// handler+callback Mark/Consume dedup is genuinely exercised — a
+// regression that re-introduced a callback double-bump would land
+// the path-scope leader counter at 2, not 1.
 func TestActivityExposesVVAfterGlobWrite(t *testing.T) {
 	monotonic.Init()
 	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
 	require.NoError(t, db.Start(storage.Options{}))
 	defer db.Close()
-	storage.WatchWithCallback(db, func(storage.Event) {})
 
 	vvm := NewVVManager(db, "leader")
 	tracker := NewHandlerWriteTracker()
+
+	keys := []Key{{Path: "things/*", Database: db}}
+	instance := &Instance{VVManager: vvm}
+	storage.WatchWithCallback(db, makeStorageSync(StorageSyncConfig{
+		Keys:           keys,
+		GetNodes:       func() []string { return nil },
+		HandlerTracker: tracker,
+		Instance:       instance,
+	}))
 
 	// Wire a Set handler the way a glob-path key registers it: path=
 	// "things" (the registered base, with the /* stripped before
@@ -100,23 +113,34 @@ func TestCallbackIncrementsAtPathScope(t *testing.T) {
 	// goroutine — a small wait is enough.
 	require.Eventually(t, func() bool {
 		return vvm.Get("things/*")["leader"] >= 1
-	}, 1*1_000_000_000, 5*1_000_000,
+	}, time.Second, 5*time.Millisecond,
 		"storage callback must increment path-scope VV on direct writes")
 }
 
 // TestHandlerIncrementMatchesActivityScope pins the symmetry: every
 // handler-driven write produces a VV that Activity exposes 1:1. If a
-// future change re-introduces an item-scope increment, this test
-// regresses immediately.
+// future change re-introduces an item-scope increment, OR if the
+// callback dedup regresses and double-bumps, this test fails (3 writes
+// must produce exactly 3, not 6).
 func TestHandlerIncrementMatchesActivityScope(t *testing.T) {
 	monotonic.Init()
 	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
 	require.NoError(t, db.Start(storage.Options{}))
 	defer db.Close()
-	storage.WatchWithCallback(db, func(storage.Event) {})
 
 	vvm := NewVVManager(db, "leader")
-	setHandler := Set(db, "things", NewHandlerWriteTracker(), vvm, nil)
+	tracker := NewHandlerWriteTracker()
+
+	keys := []Key{{Path: "things/*", Database: db}}
+	instance := &Instance{VVManager: vvm}
+	storage.WatchWithCallback(db, makeStorageSync(StorageSyncConfig{
+		Keys:           keys,
+		GetNodes:       func() []string { return nil },
+		HandlerTracker: tracker,
+		Instance:       instance,
+	}))
+
+	setHandler := Set(db, "things", tracker, vvm, nil)
 
 	for i, idx := range []string{"a", "b", "c"} {
 		body := strings.NewReader(`{"created":0,"updated":0,"index":"` + idx + `","path":"things/` + idx + `","data":"e30="}`)
@@ -128,12 +152,17 @@ func TestHandlerIncrementMatchesActivityScope(t *testing.T) {
 		require.Equal(t, 200, w.Code, "write %d failed", i)
 	}
 
+	// Wait for the watch goroutine to drain. Once tracker is empty, every
+	// handler Mark has been Consumed by the callback (callback skipped
+	// each).
+	require.Eventually(t, func() bool { return tracker.pendingLen() == 0 }, time.Second, 5*time.Millisecond)
+
 	// Three writes under the same registered glob path → one VV with
 	// leader counter at 3. Pre-fix each write bumped a separate item-
 	// scope VV (things/a, things/b, things/c) — none of which /activity
-	// would have read.
+	// would have read. Asserting exactly 3 (not >=3) catches a regression
+	// that lets the callback also bump (would land 6).
 	exposedVV := vvm.Get("things/*")
 	require.Equal(t, int64(3), exposedVV["leader"],
-		"three writes under things/* must increment the path-scope VV by 3; got %v", exposedVV)
-	_ = http.StatusOK // keep import
+		"three writes under things/* must increment the path-scope VV by exactly 3; got %v", exposedVV)
 }


### PR DESCRIPTION
## Summary
First half of #45. Unifies the VV system on path scope so writes (`increment`) and reads (`/activity`, `lastSyncedVV` cache) reference the same VV entry.

Pre-fix the two halves were at different scopes and `/activity` for glob-path keys returned an empty VV unconditionally — every VV-aware sync feature silently degraded to LastEntry-only logic. PRs #42 (sync direction) and the recent #44 attempt (idempotency guard) only worked for non-glob keys, by coincidence of item-scope == path-scope for single-segment registered keys.

## What changed
- **handlers.go** — `Set` and `Delete` handlers call `vvManager.increment(path)` (the registered base) instead of `increment(itemKey)`.
- **sync.go callback** — `makeStorageSync` calls `cfg.Instance.VVManager.increment(matchedKey)` (already at base scope) instead of `increment(event.Key)`.
- **sync.go pullKeyWithCacheUpdate** — adds `LastEntry` as a secondary signal alongside the VV branch. `LastEntry` advances synchronously with the storage write; the VV bump for direct (non-handler) writes runs in the async storage-event-callback goroutine and can briefly lag. Without the secondary signal, a read landing in that lag window sees `activityPivot.VV == lastSyncedVV` (no advance yet) and skips a needed pull.

## Test plan
- [x] `TestActivityExposesVVAfterGlobWrite` — pin that `/activity` returns a non-empty VV after a glob-path Set.
- [x] `TestCallbackIncrementsAtPathScope` — pin storage callback bumps at path scope on direct writes.
- [x] `TestHandlerIncrementMatchesActivityScope` — three writes under `things/*` produce path-scope `leader=3` (asserts exactly 3, not `>= 3`, so a regression that lets handler+callback both bump would land 6).
- [x] All three new tests wire the production `makeStorageSync` callback so the Mark/Consume dedup is genuinely exercised.
- [x] Existing `TestSyncOnRead` keeps passing — the LastEntry secondary signal closes the VV-lag gap that otherwise breaks sync-on-read.
- [x] Full pivot suite green at `go test -race -count=3`.

## Out of scope
The other half of #45 — merge-on-receive, so peer counters land in local VV — is a separate PR. Without it, cross-node `Compare()` still returns `VVConcurrent` for genuinely different node histories. This PR makes `/activity` work, which is the prerequisite.

## Review history
One independent review round. No blockers. Non-blockers addressed: production callback wired in two tests that were silenced (real regression hazard), dropped a dead `_ = http.StatusOK` line and a dead `_ = indices`, replaced ns-as-int duration literals with `time.Second`/`time.Millisecond`, fixed a stale `vvm.Get(itemKey)` from before the scope sweep, tightened the LastEntry-secondary-signal comment.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
