### PR TITLE
fix(handlers): VV-driven idempotency guard on inbound Set/Delete

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -201,7 +201,6 @@ func Delete(db storage.Database, path string, handlerTracker *HandlerWriteTracke
 			// Glob pattern delete (e.g., "things/123")
 			itemKey = path + "/" + index
 		}
-		originatorPeer := r.Header.Get(OriginatorHeader)
 		// Idempotency guard via the originator's VV — same shape as the
 		// Set handler. A retried or stale Delete whose VV is dominated
 		// must not remove a newer local write.
@@ -215,6 +214,7 @@ func Delete(db storage.Database, path string, handlerTracker *HandlerWriteTracke
 				}
 			}
 		}
+		originatorPeer := r.Header.Get(OriginatorHeader)
 		if handlerTracker != nil {
 			handlerTracker.Mark(itemKey)
 		}

--- a/handlers.go
+++ b/handlers.go
@@ -110,6 +110,27 @@ func Set(db storage.Database, path string, handlerTracker *HandlerWriteTracker, 
 		if index == "" {
 			itemKey = path
 		}
+		// Idempotency guard via the originator's VV. A retried Trigger or
+		// a delayed coalescer drainer can deliver a write whose VV is
+		// dominated by what pivot already holds — without this skip, the
+		// stale write would clobber a newer locally-pivoted one. VV is
+		// the right signal because the codebase deliberately allows
+		// older-timestamped writes with higher counters
+		// (TestClockDriftScenario), so timestamp comparison can't be
+		// used. Skip on VVGreater (local strictly dominates) and VVEqual
+		// (exact retry of an already-applied write); proceed on VVLess
+		// and VVConcurrent (inbound has new info worth integrating).
+		// Missing/empty header = older peer, fall through (backward compat).
+		if vvManager != nil {
+			if peerVV, ok := decodeVVHeader(r.Header.Get(VVHeader)); ok {
+				localVV := vvManager.Get(path)
+				cmp := localVV.Compare(peerVV)
+				if cmp == VVGreater || cmp == VVEqual {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+			}
+		}
 		// Mark before the storage write so the dedup signal is in place
 		// by the time the watch goroutine processes the event. The
 		// originator header is captured locally for the post-write fanout
@@ -181,6 +202,19 @@ func Delete(db storage.Database, path string, handlerTracker *HandlerWriteTracke
 			itemKey = path + "/" + index
 		}
 		originatorPeer := r.Header.Get(OriginatorHeader)
+		// Idempotency guard via the originator's VV — same shape as the
+		// Set handler. A retried or stale Delete whose VV is dominated
+		// must not remove a newer local write.
+		if vvManager != nil {
+			if peerVV, ok := decodeVVHeader(r.Header.Get(VVHeader)); ok {
+				localVV := vvManager.Get(path)
+				cmp := localVV.Compare(peerVV)
+				if cmp == VVGreater || cmp == VVEqual {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+			}
+		}
 		if handlerTracker != nil {
 			handlerTracker.Mark(itemKey)
 		}

--- a/idempotency_guard_test.go
+++ b/idempotency_guard_test.go
@@ -105,8 +105,6 @@ func TestSetGuardSkipsExactRetry(t *testing.T) {
 
 	require.Equal(t, int64(0), vvm.Get("things")["leader"],
 		"VVEqual must skip — leader counter must not advance from a duplicate")
-	require.Equal(t, int64(1), vvm.Get("things")["10.0.0.1:9000"],
-		"peer counter from the seed must be preserved (no merge on skip)")
 }
 
 // TestSetGuardAcceptsHigherVV: inbound strictly dominates local
@@ -213,6 +211,90 @@ func TestSetGuardPreservesClockDriftScenario(t *testing.T) {
 	require.NoError(t, err)
 	require.JSONEq(t, `{"phase":"corrected"}`, string(got.Data),
 		"VVLess (higher counter, older timestamp) must be accepted — this is the clock-drift recovery path")
+	// Strengthen vs TestSetGuardAcceptsHigherVV: also assert the storage
+	// layer's Updated timestamp now reflects the corrected value (100),
+	// not the future-timestamped seed (999). Catches a hypothetical
+	// regression that retains storage state on the proceed path.
+	require.Equal(t, int64(100), got.Updated,
+		"corrected (older) timestamp must overwrite the future-timestamped record")
+}
+
+// TestSetGuardProceedsOnVVConcurrent: each side has unique counters
+// the other hasn't seen (VVConcurrent). The guard must proceed —
+// inbound has new info worth integrating; the merge step that runs
+// after the guard lands the peer counter into local. This pins the
+// VVConcurrent → proceed convention shared with pullKeyWithCacheUpdate.
+func TestSetGuardProceedsOnVVConcurrent(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+	storage.WatchWithCallback(db, func(storage.Event) {})
+
+	_, err := db.SetWithMeta("things/x", []byte(`{"v":"local"}`), 100, 100)
+	require.NoError(t, err)
+
+	vvm := NewVVManager(db, "leader")
+	// Local has counters inbound doesn't know about; inbound has counters
+	// local doesn't know about → VVConcurrent.
+	vvm.set("things/*", VersionVector{"leader": 5})
+	handler := Set(db, "things", NewHandlerWriteTracker(), vvm, nil)
+
+	obj := meta.Object{Created: 200, Updated: 200, Index: "x", Path: "things/x", Data: []byte(`{"v":"from-A"}`)}
+	body, err := json.Marshal(obj)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/_pivot/pivot/things/x", bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"index": "x"})
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(VVHeader, `{"10.0.0.1:9000":3}`) // disjoint from local → VVConcurrent
+	w := httptest.NewRecorder()
+	handler(w, req)
+	require.Equal(t, 200, w.Code)
+
+	got, err := db.Get("things/x")
+	require.NoError(t, err)
+	require.JSONEq(t, `{"v":"from-A"}`, string(got.Data),
+		"VVConcurrent must proceed — inbound has unique writes worth integrating")
+
+	// Merge from #47 lands the peer counter; the leader counter advances
+	// from the handler's own increment(path).
+	mergedVV := vvm.Get("things")
+	require.Equal(t, int64(6), mergedVV["leader"], "leader bumped from 5 → 6 by handler increment")
+	require.Equal(t, int64(3), mergedVV["10.0.0.1:9000"], "peer counter merged from inbound VV")
+}
+
+// TestSetGuardProceedsOnMalformedHeader: a truncated/garbled JSON in
+// X-Pivot-VV must not jam the handler — decodeVVHeader returns false,
+// guard falls through, write proceeds. Locks the failure mode of a
+// proxy or buggy peer that ships an unparseable header.
+func TestSetGuardProceedsOnMalformedHeader(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+	storage.WatchWithCallback(db, func(storage.Event) {})
+
+	vvm := NewVVManager(db, "leader")
+	vvm.set("things/*", VersionVector{"leader": 5}) // would dominate if compared
+	handler := Set(db, "things", NewHandlerWriteTracker(), vvm, nil)
+
+	obj := meta.Object{Created: 100, Updated: 100, Index: "x", Path: "things/x", Data: []byte(`{"v":"applied"}`)}
+	body, err := json.Marshal(obj)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/_pivot/pivot/things/x", bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"index": "x"})
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(VVHeader, "{not valid json") // garbled
+	w := httptest.NewRecorder()
+	handler(w, req)
+	require.Equal(t, 200, w.Code)
+
+	got, err := db.Get("things/x")
+	require.NoError(t, err)
+	require.JSONEq(t, `{"v":"applied"}`, string(got.Data),
+		"malformed VV header must not block the write — guard falls through")
 }
 
 // TestDeleteGuardSkipsStaleTombstone mirrors the Set test for Delete.

--- a/idempotency_guard_test.go
+++ b/idempotency_guard_test.go
@@ -1,0 +1,244 @@
+package pivot
+
+// Regression tests for the VV-driven idempotency guard on the Set and
+// Delete handlers (closes #44). Without it, a retried Trigger or a
+// delayed coalescer drainer can deliver an inbound write whose VV is
+// dominated by what pivot already holds — the older write would
+// otherwise clobber a newer locally-pivoted one.
+//
+// Prerequisites (now in place via #46 + #47): VV is scoped consistently
+// at path scope, and pivot merges peer counters from the X-Pivot-VV
+// header into local VV. With those two foundations, localVV.Compare(
+// inboundVV) produces meaningful Greater/Less/Equal/Concurrent results.
+//
+// Guard policy:
+//   - VVGreater (local strictly dominates): skip — inbound is stale.
+//   - VVEqual (identical): skip — exact retry of an already-applied write.
+//   - VVLess: proceed — inbound has strictly newer info.
+//   - VVConcurrent: proceed — both sides have unique writes; merge will
+//     integrate inbound's peer counters and let downstream sync resolve.
+//   - Missing/empty header (older peer): proceed — backward compat.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/benitogf/ooo/meta"
+	"github.com/benitogf/ooo/monotonic"
+	"github.com/benitogf/ooo/storage"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetGuardSkipsStaleRetry pins the canonical clobber-prevention
+// case: pivot has bumped its leader counter past the inbound's view
+// (operator wrote locally after the originator's last sync), the
+// inbound's VV is strictly dominated, the handler must skip the write
+// AND keep the newer local data.
+func TestSetGuardSkipsStaleRetry(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+	storage.WatchWithCallback(db, func(storage.Event) {})
+
+	// Seed local with the newer "operator" value. Local VV reflects a
+	// prior synced write from node A (A:2) and the operator's local
+	// bump (leader:5). Inbound's view is {leader:4, A:2} — A had
+	// observed pivot at leader:4 before the operator's bump.
+	_, err := db.SetWithMeta("things/x", []byte(`{"v":"newer"}`), 100, 100)
+	require.NoError(t, err)
+
+	vvm := NewVVManager(db, "leader")
+	vvm.set("things/*", VersionVector{"leader": 5, "10.0.0.1:9000": 2})
+	handler := Set(db, "things", NewHandlerWriteTracker(), vvm, nil)
+
+	staleObj := meta.Object{Created: 50, Updated: 50, Index: "x", Path: "things/x", Data: []byte(`{"v":"stale"}`)}
+	staleBody, err := json.Marshal(staleObj)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/_pivot/pivot/things/x", bytes.NewReader(staleBody))
+	req = mux.SetURLVars(req, map[string]string{"index": "x"})
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(VVHeader, `{"10.0.0.1:9000":2,"leader":4}`) // strictly dominated
+	w := httptest.NewRecorder()
+	handler(w, req)
+	require.Equal(t, 200, w.Code, "stale retry must be idempotent (200)")
+
+	got, err := db.Get("things/x")
+	require.NoError(t, err)
+	require.JSONEq(t, `{"v":"newer"}`, string(got.Data),
+		"VVGreater must NOT clobber the newer local value")
+}
+
+// TestSetGuardSkipsExactRetry pins the no-double-bump invariant: an
+// identical-VV duplicate of an already-applied write must not bump the
+// local leader counter a second time.
+func TestSetGuardSkipsExactRetry(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+	storage.WatchWithCallback(db, func(storage.Event) {})
+
+	_, err := db.SetWithMeta("things/x", []byte(`{"v":"v1"}`), 100, 100)
+	require.NoError(t, err)
+
+	vvm := NewVVManager(db, "leader")
+	vvm.set("things/*", VersionVector{"10.0.0.1:9000": 1})
+	handler := Set(db, "things", NewHandlerWriteTracker(), vvm, nil)
+
+	obj := meta.Object{Created: 100, Updated: 100, Index: "x", Path: "things/x", Data: []byte(`{"v":"v1"}`)}
+	body, err := json.Marshal(obj)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/_pivot/pivot/things/x", bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"index": "x"})
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(VVHeader, `{"10.0.0.1:9000":1}`)
+	w := httptest.NewRecorder()
+	handler(w, req)
+	require.Equal(t, 200, w.Code)
+
+	require.Equal(t, int64(0), vvm.Get("things")["leader"],
+		"VVEqual must skip — leader counter must not advance from a duplicate")
+	require.Equal(t, int64(1), vvm.Get("things")["10.0.0.1:9000"],
+		"peer counter from the seed must be preserved (no merge on skip)")
+}
+
+// TestSetGuardAcceptsHigherVV: inbound strictly dominates local
+// (VVLess from local's perspective). Proceeds normally.
+func TestSetGuardAcceptsHigherVV(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+	storage.WatchWithCallback(db, func(storage.Event) {})
+
+	_, err := db.SetWithMeta("things/x", []byte(`{"v":"older"}`), 100, 100)
+	require.NoError(t, err)
+
+	vvm := NewVVManager(db, "leader")
+	vvm.set("things/*", VersionVector{"10.0.0.1:9000": 1})
+	handler := Set(db, "things", NewHandlerWriteTracker(), vvm, nil)
+
+	newerObj := meta.Object{Created: 200, Updated: 200, Index: "x", Path: "things/x", Data: []byte(`{"v":"newer"}`)}
+	body, err := json.Marshal(newerObj)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/_pivot/pivot/things/x", bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"index": "x"})
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(VVHeader, `{"10.0.0.1:9000":2}`) // strictly dominates local
+	w := httptest.NewRecorder()
+	handler(w, req)
+	require.Equal(t, 200, w.Code)
+
+	got, err := db.Get("things/x")
+	require.NoError(t, err)
+	require.JSONEq(t, `{"v":"newer"}`, string(got.Data),
+		"VVLess must let the inbound write replace local")
+}
+
+// TestSetGuardProceedsWithoutHeader pins backward compat: an older
+// peer that doesn't emit the header must still be accepted.
+func TestSetGuardProceedsWithoutHeader(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+	storage.WatchWithCallback(db, func(storage.Event) {})
+
+	vvm := NewVVManager(db, "leader")
+	// Seed local VV that *would* dominate if compared.
+	vvm.set("things/*", VersionVector{"leader": 5})
+	handler := Set(db, "things", NewHandlerWriteTracker(), vvm, nil)
+
+	obj := meta.Object{Created: 100, Updated: 100, Index: "x", Path: "things/x", Data: []byte(`{"v":"from-old-peer"}`)}
+	body, err := json.Marshal(obj)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/_pivot/pivot/things/x", bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"index": "x"})
+	req.Header.Set("Content-Type", "application/json")
+	// No VVHeader.
+	w := httptest.NewRecorder()
+	handler(w, req)
+	require.Equal(t, 200, w.Code)
+
+	got, err := db.Get("things/x")
+	require.NoError(t, err)
+	require.JSONEq(t, `{"v":"from-old-peer"}`, string(got.Data),
+		"missing header must fall back to existing accept-all behavior")
+}
+
+// TestSetGuardPreservesClockDriftScenario is the canary: the canonical
+// clock-drift scenario — node bumped its counter to N+1 after a clock
+// correction, sending a write with an OLDER timestamp but a HIGHER VV
+// counter — must still be accepted. Without VV-driven dispatch, the
+// timestamp-only check would reject it (the original failure mode).
+func TestSetGuardPreservesClockDriftScenario(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+	storage.WatchWithCallback(db, func(storage.Event) {})
+
+	// Local has the future-timestamped write at A:1. Pivot's local VV
+	// reflects {A:1}.
+	_, err := db.SetWithMeta("things/x", []byte(`{"phase":"future"}`), 999, 999)
+	require.NoError(t, err)
+
+	vvm := NewVVManager(db, "leader")
+	vvm.set("things/*", VersionVector{"10.0.0.1:9000": 1})
+	handler := Set(db, "things", NewHandlerWriteTracker(), vvm, nil)
+
+	// Node sends with corrected (older) timestamp but bumped VV {A:2}.
+	correctedObj := meta.Object{Created: 100, Updated: 100, Index: "x", Path: "things/x", Data: []byte(`{"phase":"corrected"}`)}
+	body, err := json.Marshal(correctedObj)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/_pivot/pivot/things/x", bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"index": "x"})
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(VVHeader, `{"10.0.0.1:9000":2}`)
+	w := httptest.NewRecorder()
+	handler(w, req)
+	require.Equal(t, 200, w.Code)
+
+	got, err := db.Get("things/x")
+	require.NoError(t, err)
+	require.JSONEq(t, `{"phase":"corrected"}`, string(got.Data),
+		"VVLess (higher counter, older timestamp) must be accepted — this is the clock-drift recovery path")
+}
+
+// TestDeleteGuardSkipsStaleTombstone mirrors the Set test for Delete.
+func TestDeleteGuardSkipsStaleTombstone(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+	storage.WatchWithCallback(db, func(storage.Event) {})
+
+	_, err := db.SetWithMeta("things/x", []byte(`{"v":"newer"}`), 100, 100)
+	require.NoError(t, err)
+
+	vvm := NewVVManager(db, "leader")
+	vvm.set("things/*", VersionVector{"leader": 5, "10.0.0.1:9000": 2})
+	handler := Delete(db, "things", NewHandlerWriteTracker(), vvm, nil)
+
+	deleteTS := strconv.FormatInt(50, 10)
+	req := httptest.NewRequest("DELETE", "/_pivot/pivot/things/x/"+deleteTS, nil)
+	req = mux.SetURLVars(req, map[string]string{"index": "x", "time": deleteTS})
+	req.Header.Set(VVHeader, `{"10.0.0.1:9000":2,"leader":4}`) // strictly dominated
+	w := httptest.NewRecorder()
+	handler(w, req)
+	require.Equal(t, 200, w.Code)
+
+	got, err := db.Get("things/x")
+	require.NoError(t, err, "VVGreater Delete must NOT remove the newer local item")
+	require.JSONEq(t, `{"v":"newer"}`, string(got.Data))
+}


### PR DESCRIPTION
## Summary
Closes #44.

A retried Trigger or a delayed coalescer drainer can deliver an inbound write whose VV is dominated by what pivot already holds. Without a guard, that stale write clobbers a newer locally-pivoted one. The Set/Delete handlers now read `X-Pivot-VV` and skip when local strictly dominates or matches.

This PR was originally attempted earlier in the cycle (timestamp-based) and rolled back because timestamp comparison can't be the guard — the codebase deliberately allows older-timestamped writes with higher VV counters (clock-drift recovery, exercised by `TestClockDriftScenario`). The proper fix needed the VV foundation: PR #46 (path-scope unification) and PR #47 (merge-on-receive). Now that both are in, `localVV.Compare(peerVV)` produces meaningful results and the guard fires correctly.

## Guard policy
| Compare result | Action |
| --- | --- |
| `VVGreater` (local strictly dominates) | skip — inbound is stale |
| `VVEqual` (identical) | skip — exact retry of an already-applied write |
| `VVLess` | proceed — inbound has strictly newer info |
| `VVConcurrent` | proceed — inbound has unique writes; merge integrates them |
| no/empty/malformed header | proceed — backward compat with older peers |

Skips return `200` so the caller treats the no-op as success and doesn't retry; no VV bump and no fanout because nothing changed locally. The VVConcurrent → proceed convention matches `pullKeyWithCacheUpdate` and `synchronizeItemWithTracking`.

## Test plan
- [x] `TestSetGuardSkipsStaleRetry` — VVGreater scenario; local "newer" survives.
- [x] `TestSetGuardSkipsExactRetry` — VVEqual scenario; leader counter must NOT advance.
- [x] `TestSetGuardAcceptsHigherVV` — VVLess scenario; inbound replaces local.
- [x] `TestSetGuardProceedsOnVVConcurrent` — concurrent counters → proceed; merge lands the peer counter.
- [x] `TestSetGuardProceedsWithoutHeader` — backward compat with peers that don't emit the header.
- [x] `TestSetGuardProceedsOnMalformedHeader` — garbled JSON in the header must not block writes.
- [x] `TestSetGuardPreservesClockDriftScenario` — older timestamp + higher VV must be accepted (the canary).
- [x] `TestDeleteGuardSkipsStaleTombstone` — Delete VVGreater path.
- [x] `TestClockDriftScenario` (existing offline-sync test) still passes — the canonical clock-correction recovery.
- [x] Full pivot suite green at `go test -race -count=3` (52s).
- [x] Flaky-check (per `.windsurf/workflows/flaky-check.md`): 100 iterations clean; longer run in progress toward 1000.

## Review history
One independent review pass; no blockers. Cleanup commit addressed five non-blockers: dropped a vacuous "no merge on skip" assertion, strengthened the clock-drift test beyond duplicate coverage, added the missing VVConcurrent and malformed-header tests, and fixed a cosmetic ordering asymmetry in Delete (originatorPeer capture moved below the guard to match Set).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
