### PR TITLE
feat(routes): widen sync index regex via key.PathPattern

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -13,13 +13,13 @@ import (
 	"time"
 
 	"github.com/benitogf/auth"
+	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/client"
 	ooio "github.com/benitogf/ooo/io"
 	"github.com/benitogf/ooo/key"
 	"github.com/benitogf/ooo/storage"
 	"github.com/benitogf/pivot"
-	"github.com/benitogf/go-json"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 )
@@ -484,6 +484,11 @@ func testClusterSync(t *testing.T, useRemote bool) {
 	var pivotThings, nodeThings []client.Meta[Thing]
 	var pivotSettings, nodeSettings []client.Meta[Settings]
 	var pivotItems, nodeItems []client.Meta[Item]
+	// Subscriptions for the special-character key sync cases. The
+	// multi-glob pattern items/cat-1/sub.v2/* lets us drive items whose
+	// path segments contain hyphens and dots while the leaf carries an
+	// underscore — exercises all three new key characters at once.
+	var pivotSpecialItems, nodeSpecialItems []client.Meta[Item]
 	var mu sync.Mutex
 
 	pivotServer, pivotWg := FakeServer(t, "")
@@ -522,7 +527,9 @@ func testClusterSync(t *testing.T, useRemote bool) {
 	}
 
 	ctx := t.Context()
-	wsWg.Add(6)
+	// 6 base subscriptions + 2 for the special-character item path = 8
+	// initial messages before any test write fires.
+	wsWg.Add(8)
 
 	// Subscribe to things, settings, and items on both servers
 	go client.SubscribeList(client.SubscribeConfig{
@@ -587,6 +594,31 @@ func testClusterSync(t *testing.T, useRemote bool) {
 	}, "items/cat/sub/*", client.SubscribeListEvents[Item]{OnMessage: func(data []client.Meta[Item]) {
 		mu.Lock()
 		nodeItems = data
+		mu.Unlock()
+		wsWg.Done()
+	}})
+	// Multi-glob subscription with special characters in the path
+	// segments — covers `-` in cat-1, `.` in sub.v2, and (via the leaf
+	// keys we write below) `_` in file_name.
+	go client.SubscribeList(client.SubscribeConfig{
+		Ctx:     ctx,
+		Server:  client.Server{Protocol: "ws", Host: pivotServer.Address},
+		Header:  authHeader,
+		Silence: true,
+	}, "items/cat-1/sub.v2/*", client.SubscribeListEvents[Item]{OnMessage: func(data []client.Meta[Item]) {
+		mu.Lock()
+		pivotSpecialItems = data
+		mu.Unlock()
+		wsWg.Done()
+	}})
+	go client.SubscribeList(client.SubscribeConfig{
+		Ctx:     ctx,
+		Server:  client.Server{Protocol: "ws", Host: nodeServer.Address},
+		Header:  authHeader,
+		Silence: true,
+	}, "items/cat-1/sub.v2/*", client.SubscribeListEvents[Item]{OnMessage: func(data []client.Meta[Item]) {
+		mu.Lock()
+		nodeSpecialItems = data
 		mu.Unlock()
 		wsWg.Done()
 	}})
@@ -894,6 +926,97 @@ func testClusterSync(t *testing.T, useRemote bool) {
 	mu.Lock()
 	require.Equal(t, 0, len(pivotItems), "pivot should have 0 items after node delete")
 	require.Equal(t, 0, len(nodeItems), "node should have 0 items after node delete")
+	mu.Unlock()
+
+	// === Special-character key sync tests ===
+	// The ooo dependency (PR #73) widens key.IsValid to admit hyphens,
+	// dots, and underscores in middle positions. Pivot's index regex
+	// for the /_pivot/<base>/{index}/{time} routes is widened to match.
+	// Verify the new characters propagate end-to-end through pivot's
+	// HTTP set/delete routes AND through both the pattern-level
+	// subscription (things/*, which still receives writes to
+	// things/<special-char-id>) and a sub-glob subscription that has
+	// special characters in its own path segments
+	// (items/cat-1/sub.v2/*).
+
+	// findThing scans a things/* subscription's state for a specific id.
+	findThing := func(list []client.Meta[Thing], id string) bool {
+		for _, m := range list {
+			if m.Index == id {
+				return true
+			}
+		}
+		return false
+	}
+	// Each id covers one of the three new characters in turn.
+	specialIDs := []string{"hyphen-id", "underscore_id", "dot.id"}
+
+	// Cycle each special-id thing through the pivot direction: pivot
+	// writes, syncs to node via the trigger fanout (the pivot Set/Delete
+	// HTTP handler is the URL surface that PR #73 widened — but the
+	// pivot's local ooo.Set→callback fanout also matters because the
+	// triggered node pulls via /pivot/things which serves entries whose
+	// indexes now legally contain hyphens, dots, and underscores).
+	for _, id := range specialIDs {
+		wsWg.Add(2)
+		ops.setThing(t, true, id, Thing{IP: "10.1.1.1", Port: 0, On: true})
+		wsWg.Wait()
+		mu.Lock()
+		require.True(t, findThing(pivotThings, id), "pivot sub should see things/%s after pivot-side set", id)
+		require.True(t, findThing(nodeThings, id), "node sub should see things/%s after sync from pivot", id)
+		mu.Unlock()
+
+		wsWg.Add(2)
+		ops.deleteThing(t, true, id)
+		wsWg.Wait()
+		mu.Lock()
+		require.False(t, findThing(pivotThings, id), "pivot sub should NOT see things/%s after delete", id)
+		require.False(t, findThing(nodeThings, id), "node sub should NOT see things/%s after sync of delete", id)
+		mu.Unlock()
+	}
+
+	// Multi-glob with special characters in the path AND the leaf key.
+	// The subscription pattern itself contains `-` (cat-1) and `.` (sub.v2);
+	// the leaf key (file_name) carries `_`. All three new characters are
+	// exercised at once. Unlike things/* — which carries tombstone activity
+	// from earlier cycles — this path starts clean, so a node-direction
+	// write can be paired with the cross-server pivot write deterministically
+	// (Add(2) = one node WS + one pivot WS). That gives node→pivot URL
+	// coverage of the widened /pivot/<base>/{index} regex without racing
+	// against stale tombstone state.
+	specialItemKey := "items/cat-1/sub.v2/file_name"
+
+	// Pivot-side set: covers /pivot fanout → node pull on a special path.
+	wsWg.Add(2)
+	ops.setItem(t, true, specialItemKey, Item{Name: "special-1", Value: 100})
+	wsWg.Wait()
+	mu.Lock()
+	require.Equal(t, 1, len(pivotSpecialItems), "pivot's special-path sub should see the new item")
+	require.Equal(t, "special-1", pivotSpecialItems[0].Data.Name)
+	require.Equal(t, 1, len(nodeSpecialItems), "node's special-path sub should see the synced item")
+	require.Equal(t, "special-1", nodeSpecialItems[0].Data.Name)
+	mu.Unlock()
+
+	// Node-side update: exercises pivot's widened {index} regex via the
+	// node→leader POST URL /pivot/items/cat-1/sub.v2/file_name. The pivot
+	// Set handler accepts the path, writes locally, and the node sees the
+	// confirmation via its WS sub.
+	wsWg.Add(2)
+	ops.setItem(t, false, specialItemKey, Item{Name: "special-2", Value: 200})
+	wsWg.Wait()
+	mu.Lock()
+	require.Equal(t, "special-2", pivotSpecialItems[0].Data.Name, "pivot should see the node-side update")
+	require.Equal(t, "special-2", nodeSpecialItems[0].Data.Name)
+	mu.Unlock()
+
+	// Node-side delete: exercises the widened {index} regex on the DELETE
+	// route too (/pivot/<base>/{index}/{time}).
+	wsWg.Add(2)
+	ops.deleteItem(t, false, specialItemKey)
+	wsWg.Wait()
+	mu.Lock()
+	require.Equal(t, 0, len(pivotSpecialItems), "pivot's special-path sub should be empty after node-side delete")
+	require.Equal(t, 0, len(nodeSpecialItems), "node's special-path sub should be empty after node-side delete")
 	mu.Unlock()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benitogf/coat v0.0.0-20200402073050-ff807656cbec
 	github.com/benitogf/go-json v0.0.0-20260410172501-727f5690408b
 	github.com/benitogf/ko v0.0.0-20260211072652-d48fcf4f8988
-	github.com/benitogf/ooo v0.0.0-20260422045849-868300e72a73
+	github.com/benitogf/ooo v0.0.0-20260512052235-a341c4f7c4d2
 	github.com/gorilla/mux v1.8.1
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/benitogf/jsonpatch v0.0.0-20260413094158-a4a6cc1a3382 h1:invi4tSUoH4H
 github.com/benitogf/jsonpatch v0.0.0-20260413094158-a4a6cc1a3382/go.mod h1:ZOQm93UFJwYDZLHQVGt2/JmNOltb6LRIJUuys0uMWKY=
 github.com/benitogf/ko v0.0.0-20260211072652-d48fcf4f8988 h1:sagWGc0GUBEMxa56HpjlYh6MmUt2O4vZrqlTspHotYc=
 github.com/benitogf/ko v0.0.0-20260211072652-d48fcf4f8988/go.mod h1:fRbtp9nrkNeDXowzM7KRJP6TL6OMsAyroUylQCw+77s=
-github.com/benitogf/ooo v0.0.0-20260422045849-868300e72a73 h1:Aqo+xOCfOKpjxBSLhPZ6fiaEOltQFMi4h5Xt2gOhI0s=
-github.com/benitogf/ooo v0.0.0-20260422045849-868300e72a73/go.mod h1:WvPwWgfK2mo3UKfR+BM/9hwHe+ZjVwZZ3rxOPcBcXnw=
+github.com/benitogf/ooo v0.0.0-20260512052235-a341c4f7c4d2 h1:rSfZEhIcei8lnQej+COM1Q3QIsajCh58L5K4rbk+t+Y=
+github.com/benitogf/ooo v0.0.0-20260512052235-a341c4f7c4d2/go.mod h1:WvPwWgfK2mo3UKfR+BM/9hwHe+ZjVwZZ3rxOPcBcXnw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/pivot.go
+++ b/pivot.go
@@ -31,6 +31,12 @@ const (
 	RoutePrefix = "/_pivot"
 	// StoragePrefix is the key prefix for pivot metadata in storage
 	StoragePrefix = "pivot/"
+	// timePattern is the gorilla/mux regex matching the {time} route variable
+	// on Delete routes. Tombstone timestamps are monotonic-clock decimal strings
+	// (see ooo.Time), so the digit class covers production payloads; the
+	// letters and `*` are retained for forward compatibility with any
+	// non-numeric scheme a caller might pass on the wire.
+	timePattern = `[a-zA-Z\*\d\/]+`
 )
 
 // Config holds the configuration for cluster synchronization.
@@ -652,10 +658,10 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 		server.Router.HandleFunc(RoutePrefix+"/activity/"+baseKey, Activity(k, vvManager)).Methods("GET")
 		if baseKey != k.Path {
 			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:"+key.PathPattern+"}", Set(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("POST")
-			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:"+key.PathPattern+"}/{time:[a-zA-Z\\*\\d\\/]+}", Delete(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("DELETE")
+			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:"+key.PathPattern+"}/{time:"+timePattern+"}", Delete(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("DELETE")
 		} else {
 			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey, Set(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("POST")
-			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{time:[a-zA-Z\\*\\d\\/]+}", Delete(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("DELETE")
+			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{time:"+timePattern+"}", Delete(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("DELETE")
 		}
 		// Expose GET routes for all synced keys
 		if baseKey != k.Path {

--- a/pivot.go
+++ b/pivot.go
@@ -651,8 +651,8 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 		}
 		server.Router.HandleFunc(RoutePrefix+"/activity/"+baseKey, Activity(k, vvManager)).Methods("GET")
 		if baseKey != k.Path {
-			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:[a-zA-Z\\*\\d\\/]+}", Set(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("POST")
-			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:[a-zA-Z\\*\\d\\/]+}/{time:[a-zA-Z\\*\\d\\/]+}", Delete(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("DELETE")
+			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:"+key.PathPattern+"}", Set(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("POST")
+			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{index:"+key.PathPattern+"}/{time:[a-zA-Z\\*\\d\\/]+}", Delete(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("DELETE")
 		} else {
 			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey, Set(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("POST")
 			server.Router.HandleFunc(RoutePrefix+"/pivot/"+baseKey+"/{time:[a-zA-Z\\*\\d\\/]+}", Delete(k.Database, baseKey, handlerTracker, vvManager, postWrite)).Methods("DELETE")


### PR DESCRIPTION
## Summary
- Bump `github.com/benitogf/ooo` to the merged build for [ooo#73](https://github.com/benitogf/ooo/pull/73), which exports `key.PathPattern` (and fixes the pre-existing subscribe/broadcast races that surfaced while validating it).
- Switch pivot's `/pivot/<base>/{index}` Set/Delete routes from a duplicated `[a-zA-Z\*\d\/]+` regex to `key.PathPattern`. Single source of truth lives in ooo; pivot inherits hyphen / dot / underscore acceptance automatically.
- Extend `testClusterSync` with special-character coverage: a 3-id cycle through the pivot direction on `things/*`, plus a multi-glob `items/cat-1/sub.v2/file_name` path that exercises the widened `{index}` regex from the node→leader direction on both POST and DELETE. The multi-glob path is used for node-direction URL coverage because it starts with no tombstone history, so cross-server writes deterministically yield one node WS + one pivot WS.

Tracks the downstream side of [benitogf/ooo#72](https://github.com/benitogf/ooo/issues/72) for the pivot HTTP route surface called out as a follow-up in that issue's scope note.

## Test plan
- [x] `go test -count=10 ./...` clean against the published `v0.0.0-20260512052235-a341c4f7c4d2` build of ooo.
- [x] `TestClusterSyncLocal` and `TestClusterSyncRemote` clean across 20+ count runs (no flakiness in the new special-char sections).
- [x] Existing `things/*`, `settings`, multi-glob `items/cat/sub/*`, and policies cases unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)