### PR TITLE
fix: clamp + VV-aware inner gate at sync ingress (two-layer defense against clock-skew poisoning)

### DIFF
--- a/clamp.go
+++ b/clamp.go
@@ -1,0 +1,68 @@
+package pivot
+
+import (
+	"log"
+	"sync/atomic"
+	"time"
+)
+
+// MaxFutureUpdatedSkew bounds how far ahead of the current wall clock an
+// incoming Updated timestamp is allowed to be before pivot clamps it.
+//
+// Pivot's sync layer uses Updated for last-write-wins ordering. A peer with
+// a clock skewed forward — by NTP misconfiguration, container clock drift,
+// a stray `date -s`, etc. — can otherwise write records with Updated values
+// minutes, hours, or years in the future. Those values then dominate every
+// present-time write at every other peer until wall-clock time catches up,
+// so a single misconfigured node can silently freeze a key for the entire
+// cluster (a `device.open=true` write succeeds locally and is immediately
+// reverted by the next pull-sync, for example).
+//
+// Clamping at ingress prevents the poison from entering the cluster's
+// storage in the first place. The bound applies at every write that
+// originates outside the local Set path:
+//
+//   - handlers.Set (POST /_pivot/{base}/{index}): pivot's receiver for
+//     peer-pushed writes.
+//   - syncSetFromLeader, syncLocalEntriesWithTracking (sync.go): pivot's
+//     pull-from-leader paths.
+//
+// The default of 5 minutes covers NTP transients and short clock jumps
+// without rejecting routine traffic. Operators with tighter clock discipline
+// can lower it; operators running virtualised peers known to drift can
+// raise it. Set to 0 to disable the clamp entirely (legacy behaviour).
+//
+// Stored as int64 nanoseconds in an atomic so the value can be tuned at
+// runtime by an operator endpoint without locks.
+var MaxFutureUpdatedSkew atomic.Int64
+
+func init() {
+	MaxFutureUpdatedSkew.Store(int64(5 * time.Minute))
+}
+
+// nowUnixNano is the wall-clock source used by clampFutureUpdated. Tests
+// substitute their own; production keeps time.Now().
+var nowUnixNano = func() int64 { return time.Now().UnixNano() }
+
+// clampFutureUpdated returns updated unchanged if it is within
+// MaxFutureUpdatedSkew of the current wall clock. If updated is farther in
+// the future than that, it is clamped to now+skew and a one-line warning is
+// logged identifying the affected key and the drift that was rejected.
+//
+// Used by every pivot ingress that accepts an externally-supplied Updated
+// timestamp. Local writes that go through Storage.Set are stamped from the
+// monotonic clock and never hit this path.
+func clampFutureUpdated(key string, updated int64) int64 {
+	skew := MaxFutureUpdatedSkew.Load()
+	if skew <= 0 {
+		return updated
+	}
+	now := nowUnixNano()
+	limit := now + skew
+	if updated > limit {
+		log.Printf("[pivot] WARN clamping future Updated for %q: was %d (%s ahead of wall clock), clamped to now+skew %d",
+			key, updated, time.Duration(updated-now), limit)
+		return limit
+	}
+	return updated
+}

--- a/clamp_test.go
+++ b/clamp_test.go
@@ -1,0 +1,144 @@
+package pivot
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/benitogf/ooo/monotonic"
+	"github.com/benitogf/ooo/storage"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClampFutureUpdated_BelowLimitPassesThrough confirms the no-op case:
+// any Updated value within MaxFutureUpdatedSkew of "now" is returned
+// unchanged. Routine NTP-disciplined traffic must not trip the clamp.
+func TestClampFutureUpdated_BelowLimitPassesThrough(t *testing.T) {
+	restore := installFixedNow(t, 1_000_000_000)
+	defer restore()
+
+	old := MaxFutureUpdatedSkew.Load()
+	MaxFutureUpdatedSkew.Store(int64(5 * time.Minute))
+	defer MaxFutureUpdatedSkew.Store(old)
+
+	// 4m59s ahead of fixed "now" — still under the 5-minute skew limit.
+	in := int64(1_000_000_000) + int64(4*time.Minute+59*time.Second)
+	got := clampFutureUpdated("things/x", in)
+	require.Equal(t, in, got, "values within MaxFutureUpdatedSkew must not be clamped")
+}
+
+// TestClampFutureUpdated_FutureBeyondLimitClamps is the bug-defeating
+// assertion: a peer's far-future Updated value lands as now+skew, not as
+// the original poisonous value.
+func TestClampFutureUpdated_FutureBeyondLimitClamps(t *testing.T) {
+	restore := installFixedNow(t, 1_000_000_000)
+	defer restore()
+
+	old := MaxFutureUpdatedSkew.Load()
+	MaxFutureUpdatedSkew.Store(int64(5 * time.Minute))
+	defer MaxFutureUpdatedSkew.Store(old)
+
+	// 24 hours in the future — well beyond the 5-minute skew tolerance.
+	in := int64(1_000_000_000) + int64(24*time.Hour)
+	got := clampFutureUpdated("things/x", in)
+	want := int64(1_000_000_000) + int64(5*time.Minute)
+	require.Equal(t, want, got, "future-skewed Updated must be clamped to now+MaxFutureUpdatedSkew")
+}
+
+// TestClampFutureUpdated_ZeroSkewDisables documents the escape hatch: an
+// operator who needs the legacy behaviour back can set MaxFutureUpdatedSkew
+// to 0 and pivot stops clamping entirely.
+func TestClampFutureUpdated_ZeroSkewDisables(t *testing.T) {
+	restore := installFixedNow(t, 1_000_000_000)
+	defer restore()
+
+	old := MaxFutureUpdatedSkew.Load()
+	MaxFutureUpdatedSkew.Store(0)
+	defer MaxFutureUpdatedSkew.Store(old)
+
+	in := int64(1_000_000_000) + int64(365*24*time.Hour) // a year in the future
+	got := clampFutureUpdated("things/x", in)
+	require.Equal(t, in, got, "skew=0 must disable the clamp")
+}
+
+// TestHandlerSet_ClampsFutureUpdatedAtIngress is the integration check.
+// A peer pushes a record with Updated 30 days in the future via the real
+// HTTP handler; storage must end up holding a clamped timestamp, not the
+// original poisonous value. Without the fix, the SetWithMeta inside the
+// handler would persist Updated = now + 30d, freezing the key for a month.
+func TestHandlerSet_ClampsFutureUpdatedAtIngress(t *testing.T) {
+	monotonic.Init()
+	restore := installFixedNow(t, time.Now().UnixNano())
+	defer restore()
+	old := MaxFutureUpdatedSkew.Load()
+	MaxFutureUpdatedSkew.Store(int64(5 * time.Minute))
+	defer MaxFutureUpdatedSkew.Store(old)
+
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+
+	tracker := NewHandlerWriteTracker()
+	vvm := NewVVManager(db, "leader")
+	handler := Set(db, "things", tracker, vvm, nil)
+
+	// Updated = 30 days ahead of the pinned "now". Body must serialise the
+	// meta.Object envelope the way real pivot peers send it.
+	farFuture := nowUnixNano() + int64(30*24*time.Hour)
+	body := strings.NewReader(
+		`{"created":0,"updated":` +
+			itoa(farFuture) +
+			`,"index":"abc","path":"things/abc","data":"e30="}`)
+	req := httptest.NewRequest("POST", "/_pivot/pivot/things/abc", body)
+	req = mux.SetURLVars(req, map[string]string{"index": "abc"})
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+	require.Equal(t, 200, rec.Code)
+
+	stored, err := db.Get("things/abc")
+	require.NoError(t, err)
+	limit := nowUnixNano() + int64(5*time.Minute)
+	require.LessOrEqual(t, stored.Updated, limit,
+		"stored Updated must not exceed now+MaxFutureUpdatedSkew; got %d (limit %d)",
+		stored.Updated, limit)
+	require.Less(t, stored.Updated, farFuture,
+		"stored Updated must NOT equal the peer's poisonous value")
+}
+
+// installFixedNow swaps the package-level nowUnixNano so the clamp tests
+// observe a deterministic "now". The previous value is returned to its
+// original state by the returned restore function.
+func installFixedNow(t *testing.T, fixed int64) func() {
+	t.Helper()
+	prev := nowUnixNano
+	nowUnixNano = func() int64 { return fixed }
+	return func() { nowUnixNano = prev }
+}
+
+// itoa is a tiny strconv.FormatInt wrapper to keep the test body readable.
+func itoa(v int64) string {
+	const digits = "0123456789"
+	if v == 0 {
+		return "0"
+	}
+	neg := v < 0
+	if neg {
+		v = -v
+	}
+	var buf [20]byte
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = digits[v%10]
+		v /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/handlers.go
+++ b/handlers.go
@@ -139,7 +139,7 @@ func Set(db storage.Database, path string, handlerTracker *HandlerWriteTracker, 
 		if handlerTracker != nil {
 			handlerTracker.Mark(itemKey)
 		}
-		_, err = db.SetWithMeta(itemKey, decoded.Data, decoded.Created, decoded.Updated)
+		_, err = db.SetWithMeta(itemKey, decoded.Data, decoded.Created, clampFutureUpdated(itemKey, decoded.Updated))
 		if err != nil {
 			// Contract: a non-nil error from the storage layer means no
 			// event was fired (verified for Layered: every error path

--- a/sync.go
+++ b/sync.go
@@ -31,6 +31,18 @@ type SyncOptions struct {
 	// content actually diverges. Optional for backward compatibility:
 	// nil falls back to LastEntry-only logic.
 	VVManager *VVManager
+	// LeaderVV is the version vector for opts.Key.Path as reported by the
+	// leader's /activity endpoint. Passed down from the orchestrator so the
+	// inner per-item dedup in syncSetFromLeader can ask "does my local VV
+	// already cover this base key?" instead of relying on the timestamp
+	// gate (local.Updated >= obj.Updated). The timestamp gate is unsafe
+	// under clock skew: a peer-written future-Updated value beats every
+	// honest present-time write until wall-clock catches up. VV is
+	// clock-independent and authoritative when present.
+	//
+	// Empty when the leader doesn't expose VV (older peer): the inner gate
+	// falls back to the legacy timestamp comparison.
+	LeaderVV VersionVector
 }
 
 // baseKeyFromPath strips all trailing glob segments (/*) from a path.
@@ -146,11 +158,40 @@ func syncLocalEntriesWithTracking(clientOpts ClientOpts, opts SyncOptions) error
 			return nil
 		}
 	}
-	// Check if local data exists and is up-to-date (skip write if timestamps match)
+	// Dedup: skip the write if local already has this revision (or is ahead).
+	//
+	// Prefer version-vector comparison when both sides have one — VV is
+	// clock-independent. The legacy timestamp comparison (local.Updated >=
+	// obj.Updated) is unsafe under clock skew: a peer that wrote with its
+	// wall clock set forward stores a future-Updated value that beats every
+	// honest present-time write until real time catches up. With VV, a
+	// clock-skewed peer's writes still carry the same VV they would carry
+	// with an honest clock, so the gate decides on causal order, not on
+	// raw timestamps.
+	//
+	// Fall back to timestamp comparison only when one side lacks a VV
+	// (older peer, or pre-SetNodeID startup window).
 	localObj, localErr := _key.Database.Get(_key.Path)
-	if localErr == nil && localObj.Updated >= obj.Updated {
-		// Local data is same or newer - no need to write
-		return nil
+	if localErr == nil {
+		if opts.VVManager != nil && len(opts.LeaderVV) > 0 {
+			baseKey := baseKeyFromPath(_key.Path)
+			localVV := opts.VVManager.Get(baseKey)
+			if len(localVV) > 0 {
+				switch localVV.Compare(opts.LeaderVV) {
+				case VVGreater, VVEqual:
+					// Local VV already covers the leader's VV — the write
+					// would be a no-op or a regression. Skip.
+					return nil
+				}
+				// VVLess or VVConcurrent — proceed with the write.
+			} else if localObj.Updated >= obj.Updated {
+				// Local has no VV yet (cold start); use the timestamp
+				// fallback for this single decision.
+				return nil
+			}
+		} else if localObj.Updated >= obj.Updated {
+			return nil
+		}
 	}
 	// Track BEFORE set so storage callback can skip this event
 	if onSet != nil {
@@ -300,6 +341,15 @@ func synchronizeItemWithTracking(clientOpts ClientOpts, opts SyncOptions) error 
 	//
 	// Fall back to LastEntry comparison when either side has no VV
 	// (older peers, or the very first sync before any VV bump).
+	// Always propagate the leader's VV (when present) so the inner per-item
+	// gate in syncLocalEntriesWithTracking / syncSetFromLeader can do
+	// VV-aware dedup independently of whether the outer direction was
+	// chosen by VV or by LastEntry. Without this, a useVV=false outer
+	// decision would leave the inner gate falling back to the wall-clock
+	// timestamp comparison, which is unsafe under clock skew (a peer's
+	// future-Updated value beats every honest present-time write).
+	opts.LeaderVV = activityLeader.VV
+
 	useVV := len(activityLeader.VV) > 0 && len(activityLocal.VV) > 0
 	if useVV {
 		switch activityLocal.VV.Compare(activityLeader.VV) {

--- a/sync.go
+++ b/sync.go
@@ -61,6 +61,14 @@ func syncLocalEntriesWithTracking(clientOpts ClientOpts, opts SyncOptions) error
 		if err != nil {
 			return err
 		}
+		// Clamp future Updated values from peers BEFORE the diff so the
+		// comparison sees the values we'd actually write. Otherwise a
+		// peer-skewed future timestamp wins the diff, gets clamped on
+		// SetWithMeta, and the next pull loops on the same record because
+		// local.Updated (clamped) < peer.Updated (still future).
+		for i := range objsLeader {
+			objsLeader[i].Updated = clampFutureUpdated(objsLeader[i].Path, objsLeader[i].Updated)
+		}
 
 		objsLocal, err := _key.Database.GetList(_key.Path)
 		if err != nil {
@@ -118,6 +126,11 @@ func syncLocalEntriesWithTracking(clientOpts ClientOpts, opts SyncOptions) error
 		_key.Database.Del(StoragePrefix + _key.Path)
 		return nil
 	}
+	// Clamp future Updated values from peers BEFORE the localObj.Updated >=
+	// obj.Updated gate below so the gate sees what we'd actually write.
+	// Otherwise a peer-skewed timestamp loses the diff on every pull and
+	// triggers a fresh clamped write forever.
+	obj.Updated = clampFutureUpdated(_key.Path, obj.Updated)
 	// Skip if this key was locally deleted and not yet synced
 	if skipSet != nil && skipSet(_key.Path) {
 		return nil

--- a/sync_innergate_vv_test.go
+++ b/sync_innergate_vv_test.go
@@ -1,0 +1,239 @@
+package pivot
+
+// Tests for the VV-aware inner dedup gate in syncSetFromLeader.
+//
+// Before the fix, the inner gate compared local.Updated >= obj.Updated to
+// decide whether to skip a redundant write. That is unsafe under clock
+// skew: a peer that wrote with its wall clock set forward stores a
+// future-Updated value that beats every honest present-time write until
+// real time catches up. With VV, the gate decides on causal order instead
+// of raw timestamps, so a clock-skewed peer's writes still resolve
+// correctly.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/benitogf/ooo/meta"
+	"github.com/benitogf/ooo/monotonic"
+	"github.com/benitogf/ooo/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInnerGate_VVEqualSkipsWriteEvenWhenLeaderUpdatedIsFuture is the
+// bug-defeating assertion. Local already has the same causal state as the
+// leader (VVEqual), but the leader serves an object whose Updated is in
+// the future — because some past peer wrote it while its wall clock was
+// skewed forward.
+//
+// Pre-fix: the inner gate at sync.go:138 sees local.Updated < obj.Updated
+// and proceeds with the write, clobbering local with the future-stamped
+// record. This is exactly the /device/open revert symptom.
+//
+// Post-fix: the gate consults the VVs (VVEqual), recognises local already
+// has this revision, and skips the write. The future-Updated value on the
+// leader is irrelevant to the decision.
+func TestInnerGate_VVEqualSkipsWriteEvenWhenLeaderUpdatedIsFuture(t *testing.T) {
+	monotonic.Init()
+	localDB := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, localDB.Start(storage.Options{}))
+	defer localDB.Close()
+	storage.WatchWithCallback(localDB, func(storage.Event) {})
+
+	const path = "things/x"
+	now := time.Now().UTC().UnixNano()
+	futureUpdated := now + int64(24*time.Hour) // 24h ahead — far beyond any clamp tolerance.
+
+	// Local has the "current" record stamped at present.
+	localBody := json.RawMessage(`{"v":"current"}`)
+	_, err := localDB.SetWithMeta(path, localBody, now, now)
+	require.NoError(t, err)
+
+	// Local and leader both report the same VV (VVEqual) — i.e. local
+	// already has every write the leader has ever applied to this key.
+	sameVV := VersionVector{"leader": 7}
+	vvm := NewVVManager(localDB, "127.0.0.1:9000")
+	vvm.set("things/x", sameVV)
+
+	// Leader stub: activity reports the equal VV; the per-item GET serves
+	// a record with Updated in the future. If the inner gate fell back to
+	// the timestamp comparison, this would clobber local.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_pivot/activity/"+path, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ActivityEntry{LastEntry: futureUpdated, VV: sameVV})
+	})
+	mux.HandleFunc("/_pivot/pivot/"+path, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(meta.Object{
+				Path:    path,
+				Index:   "x",
+				Created: now,
+				Updated: futureUpdated, // poison value
+				Data:    json.RawMessage(`{"v":"stale-future"}`),
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	leader := srv.URL[len("http://"):]
+
+	// Drive the same pull path production uses for a single-item key.
+	clientOpts := ClientOpts{Client: srv.Client(), Leader: leader}
+	err = synchronizeItemWithTracking(clientOpts, SyncOptions{
+		Key:        Key{Path: path, Database: localDB},
+		Originator: "127.0.0.1:9000",
+		VVManager:  vvm,
+	})
+	// VVEqual returns "nothing to synchronize" — the orchestrator never
+	// even reaches the inner gate. That's the right outcome.
+	require.Error(t, err, "VVEqual must short-circuit before any write")
+	require.Equal(t, "nothing to synchronize for "+path, err.Error())
+
+	// Confirm local was NOT clobbered: data and Updated unchanged.
+	got, err := localDB.Get(path)
+	require.NoError(t, err)
+	require.JSONEq(t, string(localBody), string(got.Data),
+		"local data must not have been overwritten by the future-stamped leader record")
+	require.Equal(t, now, got.Updated,
+		"local Updated must still be the original present-time value, not the leader's future poison")
+}
+
+// TestInnerGate_VVGreaterSkipsWriteEvenWhenLeaderUpdatedIsFuture: local's
+// VV strictly dominates leader's (local has every write the leader has,
+// plus extras). Pre-fix the inner gate would still proceed with a write
+// if the leader's served object happened to have Updated > local's. The
+// VV-aware gate skips because local is ahead.
+//
+// Drives the inner gate directly via syncLocalEntriesWithTracking with
+// LeaderVV pre-populated, bypassing the orchestrator's outer VVGreater
+// branch (which goes to syncToLeader) so we exercise the inner gate path.
+func TestInnerGate_VVGreaterSkipsWriteEvenWhenLeaderUpdatedIsFuture(t *testing.T) {
+	monotonic.Init()
+	localDB := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, localDB.Start(storage.Options{}))
+	defer localDB.Close()
+	storage.WatchWithCallback(localDB, func(storage.Event) {})
+
+	const path = "things/x"
+	now := time.Now().UTC().UnixNano()
+	futureUpdated := now + int64(24*time.Hour)
+
+	localBody := json.RawMessage(`{"v":"local-newer"}`)
+	_, err := localDB.SetWithMeta(path, localBody, now, now)
+	require.NoError(t, err)
+
+	leaderVV := VersionVector{"leader": 5}
+	localVV := VersionVector{"leader": 5, "127.0.0.1:9000": 2} // strictly greater
+	vvm := NewVVManager(localDB, "127.0.0.1:9000")
+	vvm.set("things/x", localVV)
+
+	// Leader stub returns a record with Updated in the future. With the
+	// pre-fix timestamp gate, local.Updated (now) < obj.Updated (future)
+	// would proceed with the write, regressing local to leader's older
+	// causal state.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_pivot/pivot/"+path, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(meta.Object{
+				Path:    path,
+				Index:   "x",
+				Created: now,
+				Updated: futureUpdated,
+				Data:    json.RawMessage(`{"v":"leader-older"}`),
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	leader := srv.URL[len("http://"):]
+
+	clientOpts := ClientOpts{Client: srv.Client(), Leader: leader}
+	// Call syncLocalEntriesWithTracking directly with LeaderVV populated to
+	// drive the inner gate's VV-aware decision.
+	err = syncLocalEntriesWithTracking(clientOpts, SyncOptions{
+		Key:        Key{Path: path, Database: localDB},
+		Originator: "127.0.0.1:9000",
+		VVManager:  vvm,
+		LeaderVV:   leaderVV,
+	})
+	require.NoError(t, err)
+
+	got, err := localDB.Get(path)
+	require.NoError(t, err)
+	require.JSONEq(t, string(localBody), string(got.Data),
+		"local must not regress to leader's older record under VVGreater")
+	require.Equal(t, now, got.Updated,
+		"local Updated must not be overwritten by leader's future-stamped value")
+}
+
+// TestInnerGate_VVLessAcceptsLeaderWriteEvenWhenLocalUpdatedIsHigher is
+// the inverse correctness check. Local's VV is strictly behind leader's
+// (VVLess) so we genuinely need to pull. But local's Updated happens to
+// be HIGHER than leader's — the legacy timestamp gate would refuse the
+// write and leave local diverged from the cluster.
+//
+// The VV-aware gate correctly proceeds because VVLess says leader has
+// causal state local lacks.
+func TestInnerGate_VVLessAcceptsLeaderWriteEvenWhenLocalUpdatedIsHigher(t *testing.T) {
+	monotonic.Init()
+	localDB := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, localDB.Start(storage.Options{}))
+	defer localDB.Close()
+	storage.WatchWithCallback(localDB, func(storage.Event) {})
+
+	const path = "things/x"
+	now := time.Now().UTC().UnixNano()
+	// Local Updated is "in the past" relative to wall clock — but higher
+	// than what the leader will report — to force the legacy timestamp
+	// gate to reject the leader's write.
+	localUpdated := now
+	leaderUpdated := now - int64(1*time.Hour)
+
+	_, err := localDB.SetWithMeta(path, json.RawMessage(`{"v":"local-stale"}`), localUpdated, localUpdated)
+	require.NoError(t, err)
+
+	leaderVV := VersionVector{"leader": 10} // strictly greater than local
+	localVV := VersionVector{"leader": 3}
+	vvm := NewVVManager(localDB, "127.0.0.1:9000")
+	vvm.set("things/x", localVV)
+
+	leaderBody := json.RawMessage(`{"v":"leader-canonical"}`)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_pivot/pivot/"+path, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(meta.Object{
+				Path:    path,
+				Index:   "x",
+				Created: now - int64(2*time.Hour),
+				Updated: leaderUpdated,
+				Data:    leaderBody,
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	leader := srv.URL[len("http://"):]
+
+	clientOpts := ClientOpts{Client: srv.Client(), Leader: leader}
+	err = syncLocalEntriesWithTracking(clientOpts, SyncOptions{
+		Key:        Key{Path: path, Database: localDB},
+		Originator: "127.0.0.1:9000",
+		VVManager:  vvm,
+		LeaderVV:   leaderVV,
+	})
+	require.NoError(t, err)
+
+	got, err := localDB.Get(path)
+	require.NoError(t, err)
+	require.JSONEq(t, string(leaderBody), string(got.Data),
+		"VVLess must accept the leader's write even when local Updated > leader Updated")
+}


### PR DESCRIPTION
## Summary

Two layered fixes for the same bug class: a peer with a clock skewed forward writes a record whose `Updated` is far in the future, and that value then dominates every honest present-time write at every other peer until wall-clock catches up. A `/device/open`-style write succeeds locally and is reverted by the next pull. End-to-end repro: a peer pushes a future-Updated record, every other node's local write is silently overwritten by the future-stamped record on the next pull tick.

This PR ships:

1. **Clamp future Updated at sync ingress** (db775d0). Bounds the externally-supplied `Updated` value at every place an outside timestamp can enter local storage: `handlers.Set` (peer push receive), `syncSetFromLeader` (single-key pull), and `syncLocalEntriesWithTracking` glob diff (list pull, clamped before `GetEntriesPositiveDiff` so the diff sees the value we'd actually write). `MaxFutureUpdatedSkew` defaults to 5 minutes, atomic, runtime-tunable. Set to 0 for legacy behaviour.

2. **VV-aware inner gate in `syncSetFromLeader`** (23d80ca). The dedup gate `localObj.Updated >= obj.Updated` is the actual revert mechanism: even when the orchestrator's VV-based outer decision says we should pull, the inner gate uses raw wall-clock timestamps and silently skips correct writes (when local Updated is higher than leader's despite being causally older) or accepts wrong writes (when leader Updated is a future-skewed poison value). Switch the gate to prefer VV comparison when both sides have one, fall back to timestamp only when a side lacks VV. Propagate `activityLeader.VV` to `SyncOptions.LeaderVV` unconditionally so the inner gate works even when the outer direction was chosen via LastEntry fallback.

The clamp covers the glob branch (`devices/*` etc., where per-item VV doesn't exist) and the cold-start window before nodes register a VV. The VV-aware gate makes the bug structurally unreachable on the single-key path regardless of clock state.

## Test plan

`clamp_test.go`:
- [x] Updated within tolerance passes through unchanged.
- [x] Updated 24h in the future clamps to `now + MaxFutureUpdatedSkew`.
- [x] `MaxFutureUpdatedSkew = 0` disables the clamp.
- [x] HTTP integration via `handlers.Set` with a peer-pushed Updated 30 days in the future — stored Updated is the clamped value, not the poisonous one.

`sync_innergate_vv_test.go`:
- [x] VVEqual at outer activity: leader serves a future-Updated record; local data is not clobbered.
- [x] VVGreater (local strictly dominates): inner gate skips the write even when leader's Updated is far ahead.
- [x] VVLess (leader strictly dominates): inner gate accepts the leader's write even when local's Updated happens to be higher — the inverse correctness case the legacy timestamp gate gets wrong.

\`go test -race ./...\` passes (~19s, all existing tests still green).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)