### PR TITLE
fix: run an attached storage's own pre-read hook alongside pivot's

### DIFF
--- a/attach_beforeread_test.go
+++ b/attach_beforeread_test.go
@@ -1,0 +1,49 @@
+package pivot
+
+import (
+	"testing"
+
+	"github.com/benitogf/ooo/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttachChainsUserBeforeRead pins that Attach composes the caller's
+// BeforeRead with pivot's sync-on-read callback instead of dropping it.
+// Attach's documented use case is external storages that want to read; a
+// consumer that needs its own BeforeRead (lazy-load, audit, metrics) must
+// still see it invoked, alongside pivot's. Both Attach paths are covered:
+// the not-started Start(opts) branch and the already-started
+// SetBeforeRead branch.
+func TestAttachChainsUserBeforeRead(t *testing.T) {
+	t.Run("not-started storage (Start path)", func(t *testing.T) {
+		var pivotCalled, userCalled bool
+		inst := &Instance{BeforeRead: func(string) { pivotCalled = true }}
+		db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+		require.NoError(t, inst.Attach(db, storage.Options{
+			BeforeRead: func(string) { userCalled = true },
+		}))
+		defer db.Close()
+
+		_, _ = db.Get("things/1") // read triggers BeforeRead
+
+		require.True(t, pivotCalled, "pivot sync-on-read BeforeRead must run")
+		require.True(t, userCalled, "caller's BeforeRead must run, not be dropped")
+	})
+
+	t.Run("already-started storage (SetBeforeRead path)", func(t *testing.T) {
+		var pivotCalled, userCalled bool
+		inst := &Instance{BeforeRead: func(string) { pivotCalled = true }}
+		db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+		require.NoError(t, db.Start(storage.Options{}))
+		defer db.Close()
+
+		require.NoError(t, inst.Attach(db, storage.Options{
+			BeforeRead: func(string) { userCalled = true },
+		}))
+
+		_, _ = db.Get("things/1") // read triggers BeforeRead
+
+		require.True(t, pivotCalled, "pivot sync-on-read BeforeRead must run")
+		require.True(t, userCalled, "caller's BeforeRead must run, not be dropped")
+	})
+}

--- a/instance.go
+++ b/instance.go
@@ -299,16 +299,35 @@ func (i *Instance) bumpVVForLocalWrite(eventKey string) {
 // Attach wraps the caller's AfterWrite (if any) with a synchronous VV
 // bump (see bumpVVForLocalWrite). The bump runs first, then the
 // caller's AfterWrite, so tests waiting on AfterWrite still observe the
-// post-bump VV.
+// post-bump VV. A caller-supplied BeforeRead is likewise composed with
+// pivot's sync-on-read callback (pivot first, caller second) rather than
+// dropped.
 func (i *Instance) Attach(db storage.Database, storageOpts ...storage.Options) error {
-	opts := storage.Options{BeforeRead: i.BeforeRead}
+	var opts storage.Options
 	var userAfterWrite func(string)
+	var userBeforeRead func(string)
 	if len(storageOpts) > 0 {
 		userOpts := storageOpts[0]
 		opts.NoBroadcastKeys = userOpts.NoBroadcastKeys
 		userAfterWrite = userOpts.AfterWrite
+		userBeforeRead = userOpts.BeforeRead
 		opts.Workers = userOpts.Workers
 	}
+	// Compose pivot's sync-on-read BeforeRead with the caller's (if any),
+	// rather than overwriting it. Pivot runs first so its pull lands
+	// before the caller's hook observes the key — same ordering as the
+	// AfterWrite wrapping below (pivot's bump first, caller's hook second).
+	// Attach's documented use case is external storages that want to read,
+	// so silently dropping a caller-supplied BeforeRead would defeat it.
+	beforeRead := func(eventKey string) {
+		if i.BeforeRead != nil {
+			i.BeforeRead(eventKey)
+		}
+		if userBeforeRead != nil {
+			userBeforeRead(eventKey)
+		}
+	}
+	opts.BeforeRead = beforeRead
 	opts.AfterWrite = func(eventKey string) {
 		i.bumpVVForLocalWrite(eventKey)
 		if userAfterWrite != nil {
@@ -333,7 +352,7 @@ func (i *Instance) Attach(db storage.Database, storageOpts ...storage.Options) e
 		// Store before checking Active(), then Delete immediately in
 		// this already-started branch because wrapped AfterWrite was
 		// not installable.
-		db.SetBeforeRead(i.BeforeRead)
+		db.SetBeforeRead(beforeRead)
 		// Roll back the attachedDBs record because AfterWrite was NOT
 		// actually installed (storage was already started).
 		i.attachedDBs.Delete(db)


### PR DESCRIPTION
## Summary
Closes #53 — an external storage attached to a pivot-synchronized server now keeps its own read-time hook instead of having it silently replaced by pivot's.

- A storage attached with its own pre-read hook now has that hook run on reads.
- Pivot's sync-on-read still runs first, so reads stay up to date — no longer either/or.
- Works whether the storage was already started before attaching or started by attach.

## Test plan
- [ ] A storage attached with its own read-time hook sees that hook fire on reads.
- [ ] Pivot's sync-on-read still runs (not replaced).
- [ ] Both run whether or not the storage was already started before attaching.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)