### PR TITLE
fix: health check no longer drops nodes that enable request auditing

### DIFF
--- a/nodehealth.go
+++ b/nodehealth.go
@@ -315,15 +315,22 @@ func (nh *NodeHealth) IsCompatible(node string) bool {
 	return proto == ProtocolVersion
 }
 
-// pingNode checks if a node is reachable
+// pingNode checks if a node is reachable. It probes the pivot-internal
+// /_pivot/version route rather than the ooo root ("/"): the root is served by
+// the UI handler behind the Audit gate, so a node hardened with a non-trivial
+// Audit returns 401 on "/" and would be permanently marked unhealthy. The
+// /_pivot/version route is registered without the Audit wrapper, so it stays
+// reachable. GET (not HEAD) keeps the probe compatible with older nodes that
+// registered /_pivot/version for GET only, so a rolling upgrade never marks a
+// not-yet-upgraded node unhealthy.
 func (nh *NodeHealth) pingNode(node string) bool {
 	select {
 	case <-nh.ctx.Done():
 		return false
 	default:
 	}
-	url := nh.Scheme() + "://" + node + "/"
-	req, err := http.NewRequestWithContext(nh.ctx, "GET", url, nil)
+	url := nh.Scheme() + "://" + node + RoutePrefix + "/version"
+	req, err := http.NewRequestWithContext(nh.ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return false
 	}

--- a/nodehealth_pingnode_test.go
+++ b/nodehealth_pingnode_test.go
@@ -1,0 +1,46 @@
+package pivot
+
+import (
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/benitogf/ooo"
+	"github.com/benitogf/ooo/storage"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPingNodeProbesUnauthedEndpoint pins that pingNode can reach a hardened
+// node — one whose ooo Audit denies requests — by probing the pivot-internal
+// /_pivot/version route, which is registered without the Audit wrapper.
+//
+// Before the fix, pingNode issued GET "/" against the ooo root. The root is
+// served by the UI handler, which returns 401 whenever a non-trivial Audit
+// denies the request. Every health check against a hardened node therefore
+// failed, and the node was permanently marked unhealthy. The probe now targets
+// /_pivot/version, which the Audit gate does not cover. (GET, not HEAD, so the
+// probe stays compatible with older nodes whose route registered GET only.)
+func TestPingNodeProbesUnauthedEndpoint(t *testing.T) {
+	server := &ooo.Server{}
+	server.Silence = true
+	server.Static = true
+	server.Storage = storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	server.Router = mux.NewRouter()
+	server.Client = &http.Client{Timeout: 500 * time.Millisecond}
+	// Hardened node: Audit denies everything, so the ooo root ("/") returns
+	// 401. /_pivot/version stays reachable because pivot registers it without
+	// the Audit wrapper.
+	server.Audit = func(r *http.Request) bool { return false }
+
+	Setup(server, Config{Keys: []Key{{Path: "items/*"}}, NodesKey: "nodes/*"})
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	nh := NewNodeHealth(nil)
+	defer nh.Stop()
+
+	require.True(t, nh.pingNode(server.Address),
+		"pingNode must reach a hardened node via the Audit-exempt /_pivot/version route")
+}

--- a/nodehealth_pingnode_test.go
+++ b/nodehealth_pingnode_test.go
@@ -38,6 +38,15 @@ func TestPingNodeProbesUnauthedEndpoint(t *testing.T) {
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 
+	// Premise check: the ooo root IS behind the Audit gate, so a direct GET
+	// "/" on this hardened server is rejected. If this ever stops being 401,
+	// the bug this test guards against no longer exists.
+	rootResp, err := http.Get("http://" + server.Address + "/")
+	require.NoError(t, err)
+	rootResp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, rootResp.StatusCode,
+		"premise: the ooo root must be Audit-gated on a hardened node")
+
 	nh := NewNodeHealth(nil)
 	defer nh.Stop()
 

--- a/pivot.go
+++ b/pivot.go
@@ -653,7 +653,9 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 
 	// Node health endpoint (only meaningful on pivot servers)
 	server.Router.HandleFunc(RoutePrefix+"/health/nodes", NodeHealthHandler(nodeHealth)).Methods("GET")
-	// Version endpoint for protocol detection
+	// Version endpoint for protocol detection, also used by
+	// NodeHealth.pingNode as the reachability probe. Registered without the
+	// Audit wrapper so health checks reach hardened nodes.
 	server.Router.HandleFunc(RoutePrefix+"/version", VersionHandler()).Methods("GET")
 	for _, k := range keys {
 		baseKey := baseKeyFromPath(k.Path)


### PR DESCRIPTION
## Summary
Closes #55 — a cluster node that enables request auditing is no longer wrongly marked offline and dropped from synchronization.

- The node-reachability health check now targets an endpoint that stays reachable regardless of the node's auditing / access-control configuration.
- A hardened node that is running and reachable is reported healthy and keeps syncing.
- Health checks keep working across a rolling upgrade (mixed old/new node versions).

## Test plan
- [ ] A node with request auditing enabled is reported healthy when running and reachable.
- [ ] The health probe no longer depends on the node's audit configuration.
- [ ] Health checks keep working across a rolling upgrade.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)