### PR TITLE
Reclaim per-peer workers when nodes leave a long-running cluster

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -1291,7 +1291,12 @@ func applyPivotFanout(instance *Instance, getNodes getNodes, nodeHealth *NodeHea
 	if instance == nil || instance.triggers == nil || getNodes == nil {
 		return
 	}
-	for _, node := range getNodes() {
+	nodes := getNodes()
+	// Prune drainers for nodes that have left the cluster so perNode (and its
+	// goroutines) stays bounded by current membership. Retain(nil) is a no-op,
+	// so a transient-empty read never reaps live drainers.
+	instance.triggers.Retain(nodes)
+	for _, node := range nodes {
 		// Self-marker is collapsed by peerOriginator before this is called,
 		// so an originatorPeer of "" means "no peer to skip".
 		if node == originatorPeer && originatorPeer != "" {

--- a/trigger.go
+++ b/trigger.go
@@ -42,6 +42,9 @@ type nodeTrigger struct {
 	mu      sync.Mutex
 	pending map[string]struct{} // key paths waiting to be sent
 	notify  chan struct{}       // 1-buffered wake-up signal
+
+	done   chan struct{} // closed by Retain to stop just this node's drainer
+	exited chan struct{} // closed by drain when its goroutine returns
 }
 
 func newTriggerCoalescer(client *http.Client, pool *syncerPool, health *NodeHealth) *triggerCoalescer {
@@ -81,6 +84,8 @@ func (c *triggerCoalescer) newNodeTriggerLocked(node string) *nodeTrigger {
 		parent:  c,
 		pending: make(map[string]struct{}),
 		notify:  make(chan struct{}, 1),
+		done:    make(chan struct{}),
+		exited:  make(chan struct{}),
 	}
 	c.perNode[node] = nt
 	c.wg.Add(1)
@@ -102,18 +107,24 @@ func (nt *nodeTrigger) signal(keyPath string) {
 	}
 }
 
-// drain is the per-node loop that fires HTTP triggers. Stops when
-// parent.stop is closed.
+// drain is the per-node loop that fires HTTP triggers. Stops when parent.stop
+// is closed (full shutdown) or nt.done is closed (this node reaped by Retain
+// because it left the cluster).
 func (nt *nodeTrigger) drain() {
 	defer nt.parent.wg.Done()
+	defer close(nt.exited)
 	for {
 		select {
 		case <-nt.parent.stop:
 			return
+		case <-nt.done:
+			return
 		case <-nt.notify:
-			// Re-check stop in case shutdown raced a notify.
+			// Re-check stop/done in case shutdown or a reap raced a notify.
 			select {
 			case <-nt.parent.stop:
+				return
+			case <-nt.done:
 				return
 			default:
 			}
@@ -158,6 +169,38 @@ func (nt *nodeTrigger) fire(keyPath string) {
 		} else {
 			nt.parent.health.MarkUnhealthy(nt.node)
 		}
+	}
+}
+
+// Retain prunes per-node triggers whose node is absent from current, stopping
+// each pruned node's drainer goroutine, so perNode (and its goroutines) can't
+// grow without bound as nodes leave the cluster. It is driven off the
+// write-fanout path with the authoritative membership list — event-driven, no
+// timer — which keeps pivot's deterministic-causal testing model intact.
+//
+// An empty current set is treated as "no information", not "everyone left":
+// getNodes() can momentarily return nil during a storage read error or
+// shutdown, and reaping on that would kill every live drainer only to respawn
+// it on the next write. Retain(nil) is therefore a no-op.
+func (c *triggerCoalescer) Retain(current []string) {
+	if len(current) == 0 {
+		return
+	}
+	keep := make(map[string]struct{}, len(current))
+	for _, node := range current {
+		keep[node] = struct{}{}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
+	for node, nt := range c.perNode {
+		if _, ok := keep[node]; ok {
+			continue
+		}
+		close(nt.done)
+		delete(c.perNode, node)
 	}
 }
 

--- a/trigger_test.go
+++ b/trigger_test.go
@@ -93,6 +93,91 @@ func TestTriggerCoalescerShutdownIdempotent(t *testing.T) {
 	c.Shutdown() // must not panic on already-closed stop channel
 }
 
+// TestTriggerCoalescerRetainReapsDepartedNodes pins the bound on perNode: once
+// a node leaves the cluster (drops out of the authoritative membership set
+// passed to Retain), its per-node trigger and drainer goroutine are reaped, so
+// neither perNode nor the goroutine count grows without bound under churn.
+func TestTriggerCoalescerRetainReapsDepartedNodes(t *testing.T) {
+	const numNodes = 3
+
+	var allFirstHits sync.WaitGroup
+	allFirstHits.Add(numNodes)
+	var onces [numNodes]sync.Once
+	addrs := make([]string, numNodes)
+
+	for i := range numNodes {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			onces[i].Do(allFirstHits.Done)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+		addrs[i] = srv.Listener.Addr().String()
+	}
+
+	c := newTriggerCoalescer(http.DefaultClient, nil, nil)
+	defer c.Shutdown()
+
+	for i := range numNodes {
+		c.Trigger(addrs[i], "items/*")
+	}
+	allFirstHits.Wait() // all three drainers are live and have fired once
+
+	// Capture the two drainers about to leave so we can assert their goroutines
+	// actually exit — not merely that the map shrank.
+	c.mu.Lock()
+	require.Len(t, c.perNode, numNodes)
+	departed := []*nodeTrigger{c.perNode[addrs[1]], c.perNode[addrs[2]]}
+	c.mu.Unlock()
+
+	// Membership now reports only node 0; nodes 1 and 2 have left the cluster.
+	c.Retain([]string{addrs[0]})
+
+	// The map shrinks synchronously under Retain's lock.
+	c.mu.Lock()
+	n := len(c.perNode)
+	_, kept := c.perNode[addrs[0]]
+	c.mu.Unlock()
+	require.Equal(t, 1, n, "departed nodes were not reaped from perNode")
+	require.True(t, kept, "the still-present node was reaped")
+
+	// Departed drainers exit deterministically (channel close, no poll/sleep).
+	for _, nt := range departed {
+		<-nt.exited
+	}
+}
+
+// TestTriggerCoalescerRetainEmptyIsNoOp guards the transient-empty membership
+// case: getNodes() can momentarily return nil (storage read error, shutdown),
+// and reaping on that would kill every live drainer only to respawn it on the
+// next write. Retain(nil) must leave perNode untouched.
+func TestTriggerCoalescerRetainEmptyIsNoOp(t *testing.T) {
+	var firstHit sync.WaitGroup
+	firstHit.Add(1)
+	var once sync.Once
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		once.Do(firstHit.Done)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTriggerCoalescer(http.DefaultClient, nil, nil)
+	defer c.Shutdown()
+
+	addr := srv.Listener.Addr().String()
+	c.Trigger(addr, "items/*")
+	firstHit.Wait()
+
+	c.Retain(nil) // transient-empty membership — must not reap
+
+	c.mu.Lock()
+	n := len(c.perNode)
+	_, kept := c.perNode[addr]
+	c.mu.Unlock()
+	require.Equal(t, 1, n)
+	require.True(t, kept, "Retain(nil) reaped a live node on a transient-empty membership read")
+}
+
 // TestTriggerCoalescerNoTriggersAfterShutdown verifies Trigger calls that
 // arrive after Shutdown are silent no-ops (no HTTP fire, no goroutine spawn).
 func TestTriggerCoalescerNoTriggersAfterShutdown(t *testing.T) {


### PR DESCRIPTION
## Summary
Closes #57 — a pivot instance no longer accumulates background workers for cluster members that have come and gone.

- Per-peer workers are now released as soon as a node drops out of the cluster's current membership, so resource use tracks the live cluster size instead of every address ever contacted.
- A long-running instance under membership churn (autoscaling, rolling deployments, ephemeral nodes) no longer needs a restart to reclaim the workers and memory left behind by departed members.
- Reclamation is driven by the same membership signal already used to wake peers — no new background timer, and cluster convergence and sync behavior are unchanged.
- A momentary failure to read membership is treated as "unknown" rather than "everyone left", so a transient hiccup never tears down and rebuilds the workers for healthy peers.

## Test plan
- [ ] A node that leaves the cluster has its per-peer worker released (verified: worker goroutine exits, not just bookkeeping removed).
- [ ] A still-present node keeps its worker.
- [ ] A transient-empty membership reading leaves live workers untouched.
- [ ] Full suite passes under the race detector.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)