### PR TITLE
Cancel in-flight leader requests on graceful shutdown

### DIFF
--- a/activity.go
+++ b/activity.go
@@ -3,6 +3,7 @@ package pivot
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strconv"
 
 	"github.com/benitogf/ooo/key"
@@ -86,7 +87,11 @@ func checkPivotActivity(opts ClientOpts, key string) (ActivityEntry, error) {
 
 func checkLeaderActivity(opts ClientOpts, key string) (ActivityEntry, error) {
 	var activity ActivityEntry
-	resp, err := opts.Client.Get(opts.URL(RoutePrefix + "/activity/" + key))
+	req, err := http.NewRequestWithContext(opts.reqContext(), http.MethodGet, opts.URL(RoutePrefix+"/activity/"+key), nil)
+	if err != nil {
+		return activity, err
+	}
+	resp, err := opts.Client.Do(req)
 	if err != nil {
 		return activity, err
 	}

--- a/instance.go
+++ b/instance.go
@@ -1,6 +1,7 @@
 package pivot
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -44,6 +45,8 @@ type Instance struct {
 	healthMu       sync.RWMutex                  // Protects PivotHealth map
 	extraNodeURLMu sync.RWMutex                  // Protects ExtraNodeURLs
 	shutdown       int32                         // Atomic flag to prevent access during shutdown
+	ctx            context.Context               // Instance lifetime; cancelled by Shutdown to unblock in-flight leader HTTP calls
+	cancel         context.CancelFunc            // Cancels ctx; set in Setup, invoked by Shutdown
 }
 
 // AddExtraNodeURL adds a node URL to receive sync notifications (for cluster leader servers).
@@ -62,9 +65,14 @@ func (i *Instance) GetExtraNodeURLs() []string {
 	return result
 }
 
-// Shutdown marks the instance as shutting down to prevent access during close.
+// Shutdown marks the instance as shutting down to prevent access during close,
+// and cancels the instance context so any in-flight leader HTTP calls return
+// promptly instead of waiting out the client timeout.
 func (i *Instance) Shutdown() {
 	atomic.StoreInt32(&i.shutdown, 1)
+	if i.cancel != nil {
+		i.cancel()
+	}
 }
 
 // IsShutdown returns true if the instance is shutting down.

--- a/pivot.go
+++ b/pivot.go
@@ -507,10 +507,13 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 	for _, k := range keys {
 		keyPaths = append(keyPaths, k.Path)
 	}
+	instanceCtx, instanceCancel := context.WithCancel(context.Background())
 	instance := &Instance{
 		ClusterURL:    pivotURL,
 		SyncedKeys:    keyPaths,
 		ExtraNodeURLs: config.ExtraNodeURLs,
+		ctx:           instanceCtx,
+		cancel:        instanceCancel,
 	}
 	instance.nodesCache = newNodesCache(server, config.NodesKey, instance.IsShutdown)
 
@@ -530,7 +533,7 @@ func Setup(server *ooo.Server, config Config) *ooo.Server {
 
 	// Create syncer pool for keys that need outbound sync
 	// Keys with Local=true or where server IS pivot won't have syncers
-	pool := newSyncerPool(client, keys, pivotURL, config.SSL, vvManager)
+	pool := newSyncerPool(instanceCtx, client, keys, pivotURL, config.SSL, vvManager)
 
 	// Create node health tracker
 	// NodeHealth is needed if server is pivot for ANY key (pure pivot or mixed role)

--- a/remote.go
+++ b/remote.go
@@ -17,6 +17,22 @@ type ClientOpts struct {
 	Client *http.Client
 	Leader string // Leader/pivot server address
 	SSL    bool   // Use HTTPS instead of HTTP
+
+	// ctx bounds the lifetime of requests issued with these options. The
+	// syncer stamps its instance-scoped context here (via ClientOpts) so a
+	// graceful Instance.Shutdown() cancels in-flight leader calls instead of
+	// leaving them to wait out the client timeout. Unexported: external
+	// callers leave it nil and reqContext falls back to context.Background().
+	ctx context.Context
+}
+
+// reqContext returns the request context for these options, defaulting to
+// context.Background() when no context was supplied.
+func (c ClientOpts) reqContext() context.Context {
+	if c.ctx != nil {
+		return c.ctx
+	}
+	return context.Background()
 }
 
 // Scheme returns "https" if SSL is true, "http" otherwise.
@@ -96,7 +112,11 @@ func TriggerNodeSyncWithHealth(opts ClientOpts, node string, keyPath string) boo
 
 func getEntriesFromLeader(opts ClientOpts, key string) ([]meta.Object, error) {
 	var objs []meta.Object
-	resp, err := opts.Client.Get(opts.URL(RoutePrefix + "/pivot/" + key))
+	req, err := http.NewRequestWithContext(opts.reqContext(), http.MethodGet, opts.URL(RoutePrefix+"/pivot/"+key), nil)
+	if err != nil {
+		return objs, err
+	}
+	resp, err := opts.Client.Do(req)
 	if err != nil {
 		return objs, err
 	}
@@ -119,7 +139,11 @@ func getEntriesFromLeader(opts ClientOpts, key string) ([]meta.Object, error) {
 // hasActivity is false against older leaders that don't emit the header — the
 // caller is expected to fall back to checkLeaderActivity in that case.
 func getEntriesAndActivityFromLeader(opts ClientOpts, key string) (objs []meta.Object, activity int64, hasActivity bool, err error) {
-	resp, err := opts.Client.Get(opts.URL(RoutePrefix + "/pivot/" + key))
+	req, err := http.NewRequestWithContext(opts.reqContext(), http.MethodGet, opts.URL(RoutePrefix+"/pivot/"+key), nil)
+	if err != nil {
+		return nil, 0, false, err
+	}
+	resp, err := opts.Client.Do(req)
 	if err != nil {
 		return nil, 0, false, err
 	}
@@ -146,7 +170,11 @@ func getEntriesAndActivityFromLeader(opts ClientOpts, key string) (objs []meta.O
 
 func getEntryFromLeader(opts ClientOpts, key string) (meta.Object, error) {
 	var obj meta.Object
-	resp, err := opts.Client.Get(opts.URL(RoutePrefix + "/pivot/" + key))
+	req, err := http.NewRequestWithContext(opts.reqContext(), http.MethodGet, opts.URL(RoutePrefix+"/pivot/"+key), nil)
+	if err != nil {
+		return obj, err
+	}
+	resp, err := opts.Client.Do(req)
 	if err != nil {
 		return obj, err
 	}
@@ -167,7 +195,7 @@ func getEntryFromLeader(opts ClientOpts, key string) (meta.Object, error) {
 func sendToLeader(opts ClientOpts, key string, obj meta.Object, originator string, vv VersionVector) (VersionVector, error) {
 	buf := new(bytes.Buffer)
 	json.NewEncoder(buf).Encode(obj)
-	req, err := http.NewRequest("POST", opts.URL(RoutePrefix+"/pivot/"+key), buf)
+	req, err := http.NewRequestWithContext(opts.reqContext(), http.MethodPost, opts.URL(RoutePrefix+"/pivot/"+key), buf)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +226,7 @@ func sendToLeader(opts ClientOpts, key string, obj meta.Object, originator strin
 // it locally so their VVManager reflects pivot's frontier.
 func sendDeleteToLeader(opts ClientOpts, key string, lastEntry int64, originator string, vv VersionVector) (VersionVector, error) {
 	url := opts.URL(RoutePrefix + "/pivot/" + key + "/" + strconv.FormatInt(lastEntry, 10))
-	req, err := http.NewRequest("DELETE", url, nil)
+	req, err := http.NewRequestWithContext(opts.reqContext(), http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/remote_context_test.go
+++ b/remote_context_test.go
@@ -1,0 +1,116 @@
+package pivot
+
+// Verifies that the node→leader HTTP calls in remote.go honor a caller-supplied
+// context, so a graceful Instance.Shutdown() (which cancels that context) can
+// unblock requests that are in flight against a slow or hung leader rather than
+// waiting out the client timeout.
+//
+// Pattern: a leader handler that blocks until the test releases it, a request
+// fired in a goroutine, and a cancel() that must make the call return promptly
+// with a context error. No sleeps — synchronization is via channels.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/benitogf/ooo/meta"
+	"github.com/stretchr/testify/require"
+)
+
+// hangingLeader returns a server whose handler signals once it has a request in
+// flight (reached) and then blocks until the test closes release.
+func hangingLeader(t *testing.T) (opts ClientOpts, reached <-chan struct{}, cancel context.CancelFunc) {
+	t.Helper()
+	reachedCh := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		once.Do(func() { close(reachedCh) })
+		<-release
+	}))
+	t.Cleanup(func() { close(release); srv.Close() })
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	return ClientOpts{Client: srv.Client(), Leader: srv.Listener.Addr().String(), ctx: ctx}, reachedCh, cancelFn
+}
+
+// TestInstanceShutdownCancelsContext closes the loop between Shutdown and the
+// remote calls: Shutdown must cancel the instance context that the syncer
+// stamps onto ClientOpts, which is what unblocks the in-flight calls above.
+func TestInstanceShutdownCancelsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	i := &Instance{ctx: ctx, cancel: cancel}
+
+	i.Shutdown()
+
+	require.True(t, i.IsShutdown())
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Shutdown did not cancel the instance context")
+	}
+}
+
+func TestGetEntryFromLeaderCancelsOnContextCancel(t *testing.T) {
+	opts, reached, cancel := hangingLeader(t)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := getEntryFromLeader(opts, "things/1")
+		done <- err
+	}()
+
+	<-reached // request is now in flight on the (hung) leader
+	cancel()  // mimic Instance.Shutdown() cancelling in-flight leader calls
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("getEntryFromLeader did not unblock on context cancel")
+	}
+}
+
+func TestCheckLeaderActivityCancelsOnContextCancel(t *testing.T) {
+	opts, reached, cancel := hangingLeader(t)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := checkLeaderActivity(opts, "things/*")
+		done <- err
+	}()
+
+	<-reached
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("checkLeaderActivity did not unblock on context cancel")
+	}
+}
+
+func TestSendToLeaderCancelsOnContextCancel(t *testing.T) {
+	opts, reached, cancel := hangingLeader(t)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := sendToLeader(opts, "things/1", meta.Object{Created: 1}, "", nil)
+		done <- err
+	}()
+
+	<-reached
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendToLeader did not unblock on context cancel")
+	}
+}

--- a/sync.go
+++ b/sync.go
@@ -2,6 +2,7 @@ package pivot
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -627,6 +628,7 @@ type pendingOp struct {
 type syncer struct {
 	mu        sync.Mutex
 	tracker   *pullTracker
+	ctx       context.Context // Instance lifetime; stamped onto ClientOpts so Shutdown cancels in-flight leader calls
 	client    *http.Client
 	pivot     string
 	keys      []Key
@@ -651,9 +653,10 @@ type syncer struct {
 	connected          map[string]bool  // baseKey -> true if we've received TriggerNodeSync for this key
 }
 
-func newSyncer(client *http.Client, pivot string, keys []Key, ssl bool, vvManager *VVManager) *syncer {
+func newSyncer(ctx context.Context, client *http.Client, pivot string, keys []Key, ssl bool, vvManager *VVManager) *syncer {
 	return &syncer{
 		tracker:            newPullTracker(),
+		ctx:                ctx,
 		client:             client,
 		pivot:              pivot,
 		keys:               keys,
@@ -666,9 +669,10 @@ func newSyncer(client *http.Client, pivot string, keys []Key, ssl bool, vvManage
 	}
 }
 
-// ClientOpts returns the client options for this syncer.
+// ClientOpts returns the client options for this syncer, carrying the
+// instance-scoped context so a graceful Shutdown cancels in-flight leader calls.
 func (s *syncer) ClientOpts() ClientOpts {
-	return ClientOpts{Client: s.client, Leader: s.pivot, SSL: s.ssl}
+	return ClientOpts{Client: s.client, Leader: s.pivot, SSL: s.ssl, ctx: s.ctx}
 }
 
 // syncerPool manages multiple syncers, one per unique pivot URL.
@@ -684,7 +688,7 @@ type syncerPool struct {
 // newSyncerPool creates a syncer pool from keys grouped by their effective ClusterURL.
 // configClusterURL is used as fallback for keys without explicit ClusterURL.
 // ssl enables HTTPS for URL construction.
-func newSyncerPool(client *http.Client, keys []Key, configClusterURL string, ssl bool, vvManager *VVManager) *syncerPool {
+func newSyncerPool(ctx context.Context, client *http.Client, keys []Key, configClusterURL string, ssl bool, vvManager *VVManager) *syncerPool {
 	pool := &syncerPool{
 		syncers: make(map[string]*syncer),
 		keyMap:  make(map[string]string),
@@ -706,7 +710,7 @@ func newSyncerPool(client *http.Client, keys []Key, configClusterURL string, ssl
 
 	// Create a syncer for each unique pivot URL
 	for pivotURL, pivotKeys := range keysByPivot {
-		pool.syncers[pivotURL] = newSyncer(client, pivotURL, pivotKeys, ssl, vvManager)
+		pool.syncers[pivotURL] = newSyncer(ctx, client, pivotURL, pivotKeys, ssl, vvManager)
 	}
 
 	return pool

--- a/syncer_init_test.go
+++ b/syncer_init_test.go
@@ -15,6 +15,7 @@ package pivot
 // VVManager test added in #31. WaitGroup-based synchronization, no sleeps.
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -77,7 +78,7 @@ func TestSyncerDefersSendUntilNodeAddrSet(t *testing.T) {
 	leader := newFakeLeader()
 	defer leader.close()
 
-	s := newSyncer(leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false, nil)
+	s := newSyncer(context.Background(), leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false, nil)
 
 	now := monotonic.Now()
 	obj := meta.Object{
@@ -109,7 +110,7 @@ func TestSyncerDefersDeleteUntilNodeAddrSet(t *testing.T) {
 	leader := newFakeLeader()
 	defer leader.close()
 
-	s := newSyncer(leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false, nil)
+	s := newSyncer(context.Background(), leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false, nil)
 
 	s.QueueOrSendDelete("things/abc", monotonic.Now())
 
@@ -129,7 +130,7 @@ func TestSyncerSendsImmediatelyAfterNodeAddrSet(t *testing.T) {
 	leader := newFakeLeader()
 	defer leader.close()
 
-	s := newSyncer(leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false, nil)
+	s := newSyncer(context.Background(), leader.srv.Client(), leader.addr(), []Key{{Path: "things/*"}}, false, nil)
 	const nodeAddr = "127.0.0.1:9003"
 	s.SetNodeAddr(nodeAddr)
 

--- a/vv_merge_test.go
+++ b/vv_merge_test.go
@@ -11,6 +11,7 @@ package pivot
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -179,7 +180,7 @@ func TestQueuedOpCarriesQueueTimeVV(t *testing.T) {
 	// Build a syncer with an empty nodeAddr so writes are queued, not sent
 	// immediately. We'll drain via SetNodeAddr at the end.
 	vvm := NewVVManager(db, "10.0.0.1:9000")
-	pool := newSyncerPool(srv.Client(), []Key{{Path: "things/*", Database: db}},
+	pool := newSyncerPool(context.Background(), srv.Client(), []Key{{Path: "things/*", Database: db}},
 		srv.URL[len("http://"):], false, vvm)
 
 	// Op #1: snapshot at VV {nodeA:1}.


### PR DESCRIPTION
## Summary
Closes #59 — a node shutting down gracefully no longer stalls on in-flight requests to a slow or unresponsive cluster leader.

- Outbound leader requests are now tied to the node's lifetime and are cancelled the moment a graceful shutdown begins, instead of waiting out the network timeout.
- Rolling restarts and deployments no longer pause on an unhealthy leader the node is about to stop talking to.
- Normal sync behavior and cluster convergence are unchanged; only the shutdown path is affected.

## Test plan
- [ ] An in-flight leader request returns immediately when the node begins shutting down (verified against a deliberately hung leader).
- [ ] Shutdown cancels the node's request context.
- [ ] Full suite passes under the race detector.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)