### PR TITLE
Consolidate version-vector shutdown guard to a single mechanism

### DIFF
--- a/version_vector.go
+++ b/version_vector.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"strconv"
 	"sync"
-	"sync/atomic"
 
 	"github.com/benitogf/ooo/storage"
 )
@@ -182,7 +181,7 @@ type VVManager struct {
 	vectors  map[string]VersionVector // keyPath -> version vector
 	storage  storage.Database
 	nodeID   string // ID of this node ("leader" for pivot, node path for nodes)
-	shutdown int32  // atomic flag to prevent writes during shutdown
+	shutdown bool   // guarded by mu; prevents writes during shutdown
 }
 
 // NewVVManager creates a new version vector manager.
@@ -291,8 +290,10 @@ func (m *VVManager) loadFromStorage(baseKey string) {
 // saveToStorage persists a version vector to storage.
 // Caller must hold m.mu.
 func (m *VVManager) saveToStorage(baseKey string) {
-	// Check shutdown flag to avoid racing with storage.Close()
-	if atomic.LoadInt32(&m.shutdown) != 0 {
+	// Check shutdown flag to avoid racing with storage.Close(). Both this read
+	// and Shutdown's write happen under m.mu (saveToStorage's callers hold it),
+	// so the mutex alone serializes them — no atomic needed.
+	if m.shutdown {
 		return
 	}
 	if m.storage == nil || !m.storage.Active() {
@@ -312,11 +313,12 @@ func (m *VVManager) saveToStorage(baseKey string) {
 }
 
 // Shutdown marks the manager as shutting down to prevent storage writes.
-// Should be called before closing the storage.
-// Acquires the mutex to ensure any in-progress saveToStorage completes first.
+// Should be called before closing the storage. Acquiring the mutex both
+// ensures any in-progress saveToStorage completes first and publishes the flag
+// to the next saveToStorage (which reads it under the same mutex).
 func (m *VVManager) Shutdown() {
 	m.mu.Lock()
-	atomic.StoreInt32(&m.shutdown, 1)
+	m.shutdown = true
 	m.mu.Unlock()
 }
 

--- a/vv_shutdown_guard_test.go
+++ b/vv_shutdown_guard_test.go
@@ -1,0 +1,36 @@
+package pivot
+
+// Characterization test for the VVManager shutdown guard: once Shutdown() has
+// run, saveToStorage must not write — otherwise a write could race storage
+// Close(). This pins the observable behavior so the guard's mechanism can be
+// simplified (mutex-only, no redundant atomic) without changing what callers
+// see.
+
+import (
+	"testing"
+
+	"github.com/benitogf/ooo/monotonic"
+	"github.com/benitogf/ooo/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVVManagerDoesNotPersistAfterShutdown(t *testing.T) {
+	monotonic.Init()
+	db := storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()})
+	require.NoError(t, db.Start(storage.Options{}))
+	defer db.Close()
+
+	m := NewVVManager(db, "node1")
+	m.increment("things/*") // persists things -> {node1:1}
+
+	before, err := db.Get(VVKeyPrefix + "things")
+	require.NoError(t, err)
+
+	m.Shutdown()
+	m.increment("things/*") // in-memory bumps, but the storage write must be skipped
+
+	after, err := db.Get(VVKeyPrefix + "things")
+	require.NoError(t, err)
+	require.Equal(t, string(before.Data), string(after.Data),
+		"VVManager persisted a write after Shutdown")
+}


### PR DESCRIPTION
## Summary
Closes #63 — version-vector persistence now relies on a single, clearly documented concurrency mechanism for its shutdown guard instead of two overlapping ones.

- Removes the redundant second guard so there's one obvious source of the shutdown-safety guarantee, reducing the risk of a future change touching one path and missing the other.
- No change to observable behavior: persistence still stops once shutdown has begun.

## Test plan
- [ ] No version-vector state is persisted after shutdown has begun (characterization test).
- [ ] Full suite passes under the race detector (confirms the single mechanism covers every access).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)